### PR TITLE
[CI] Fix integration tests (Feedback Welcome)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,9 +30,8 @@ jobs:
           powershell.exe 'curl http://ftp.gnu.org/gnu/aspell/w32/Aspell-0-50-3-3-Setup.exe -o aspell-installer.exe;
             curl http://ftp.gnu.org/gnu/aspell/w32/Aspell-en-0.50-2-3.exe -o aspell-en-dict.exe;
             Start-Process -Wait -FilePath .\aspell-installer.exe -Argument "/silent" -PassThru;
-            Start-Process -Wait -FilePath .\aspell-en-dict.exe -Argument "/silent" -PassThru;
-            $currentPath = [Environment]::GetEnvironmentVariable("Path", [EnvironmentVariableTarget]::User);
-            [Environment]::SetEnvironmentVariable("Path", $currentPath + ";C:\Program Files (x86)\Aspell\bin", [EnvironmentVariableTarget]::User);'
+            Start-Process -Wait -FilePath .\aspell-en-dict.exe -Argument "/silent" -PassThru;'
+          echo "C:\Program Files (x86)\Aspell\bin" >> $GITHUB_PATH
         fi
 
     - name: Test Aspell

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,11 +34,12 @@ jobs:
 
           echo "C:\Program Files (x86)\Aspell\bin" >> $GITHUB_PATH
           echo "C:\Program Files (x86)\Aspell\dict" >> $GITHUB_PATH
+          ls -l 'C:\Program Files (x86)\Aspell\dict'
         fi
 
     - name: Test Aspell
       shell: bash
-      run: aspell --version; echo "This is a smaple text with some mispelled words" | aspell --encoding=utf-8 -a
+      run: ls -l 'C:\Program Files (x86)\Aspell\dict'; aspell --version; echo "This is a smaple text with some mispelled words" | aspell --encoding=utf-8 -a
 
     - name: Setup PHP
       uses: shivammathur/setup-php@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,8 +30,10 @@ jobs:
           powershell.exe 'curl http://ftp.gnu.org/gnu/aspell/w32/Aspell-0-50-3-3-Setup.exe -o aspell-installer.exe;
             Start-Process -Wait -FilePath .\aspell-installer.exe -Argument "/silent" -PassThru;'
           powershell.exe 'curl http://ftp.gnu.org/gnu/aspell/w32/Aspell-en-0.50-2-3.exe -o aspell-en-dict.exe;
-            Start-Process -Wait -FilePath .\aspell-en-dict.exe -Argument "/silent" -PassThru;'
+            Start-Process -Wait -FilePath .\aspell-en-dict.exe -Argument "/silent" -PassThru | Out-File aspell_en_dict_log.txt;'
 
+          echo "File Output:"
+          cat aspell_en_dict_log.txt
           ls -l 'C:\Program Files (x86)\Aspell'
           echo "C:\Program Files (x86)\Aspell\bin" >> $GITHUB_PATH
           echo "C:\Program Files (x86)\Aspell\dict" >> $GITHUB_PATH

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,11 +27,13 @@ jobs:
         elif [[ "$RUNNER_OS" == "macOS" ]]; then
           brew install aspell
         elif [[ "$RUNNER_OS" == "Windows" ]]; then
-          powershell.exe 'curl http://ftp.gnu.org/gnu/aspell/w32/Aspell-0-50-3-3-Setup.exe -o aspell-installer.exe;
-            curl http://ftp.gnu.org/gnu/aspell/w32/Aspell-en-0.50-2-3.exe -o aspell-en-dict.exe;
-            Start-Process -Wait -FilePath .\aspell-installer.exe -Argument "/silent" -PassThru;
-            Start-Process -Wait -FilePath .\aspell-en-dict.exe -Argument "/silent" -PassThru;'
+        powershell.exe 'curl http://ftp.gnu.org/gnu/aspell/w32/Aspell-0-50-3-3-Setup.exe -o aspell-installer.exe;
+          curl http://ftp.gnu.org/gnu/aspell/w32/Aspell-en-0.50-2-3.exe -o aspell-en-dict.exe;
+          Start-Process -Wait -FilePath .\aspell-installer.exe -Argument "/silent" -PassThru;
+          Start-Process -Wait -FilePath .\aspell-en-dict.exe -Argument "/silent" -PassThru;'
+
           echo "C:\Program Files (x86)\Aspell\bin" >> $GITHUB_PATH
+          echo "C:\Program Files (x86)\Aspell\dict" >> $GITHUB_PATH
         fi
 
     - name: Test Aspell

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,7 +34,10 @@ jobs:
             $currentPath = [Environment]::GetEnvironmentVariable("Path", [EnvironmentVariableTarget]::User);
             [Environment]::SetEnvironmentVariable("Path", $currentPath + ";C:\Program Files (x86)\Aspell\bin", [EnvironmentVariableTarget]::User);'
         fi
-        echo "This is a smaple text with some mispelled words" | aspell --encoding=utf-8 -a
+
+    - name: Test Aspell
+      shell: bash
+      run: aspell --version; echo "This is a smaple text with some mispelled words" | aspell --encoding=utf-8 -a
 
     - name: Setup PHP
       uses: shivammathur/setup-php@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,6 +20,7 @@ jobs:
       uses: actions/checkout@v3
 
     - name: Install Aspell (Ubuntu, macOS, Windows)
+      shell: bash
       run: |
         if [[ "$RUNNER_OS" == "Linux" ]]; then
           sudo apt-get update && sudo apt-get install -y aspell aspell-en

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,7 +28,9 @@ jobs:
           brew install aspell
         elif [[ "$RUNNER_OS" == "Windows" ]]; then
           powershell.exe 'curl http://ftp.gnu.org/gnu/aspell/w32/Aspell-0-50-3-3-Setup.exe -o aspell-installer.exe;
+            curl http://ftp.gnu.org/gnu/aspell/w32/Aspell-en-0.50-2-3.exe -o aspell-en-dict.exe;
             Start-Process -Wait -FilePath .\aspell-installer.exe -Argument "/silent" -PassThru;
+            Start-Process -Wait -FilePath .\aspell-en-dict.exe -Argument "/silent" -PassThru;
             $currentPath = [Environment]::GetEnvironmentVariable("Path", [EnvironmentVariableTarget]::User);
             [Environment]::SetEnvironmentVariable("Path", $currentPath + ";C:\Program Files (x86)\Aspell\bin", [EnvironmentVariableTarget]::User);'
         fi

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,10 +27,10 @@ jobs:
         elif [[ "$RUNNER_OS" == "macOS" ]]; then
           brew install aspell
         elif [[ "$RUNNER_OS" == "Windows" ]]; then
-        powershell.exe 'curl http://ftp.gnu.org/gnu/aspell/w32/Aspell-0-50-3-3-Setup.exe -o aspell-installer.exe;
-          curl http://ftp.gnu.org/gnu/aspell/w32/Aspell-en-0.50-2-3.exe -o aspell-en-dict.exe;
-          Start-Process -Wait -FilePath .\aspell-installer.exe -Argument "/silent" -PassThru;
-          Start-Process -Wait -FilePath .\aspell-en-dict.exe -Argument "/silent" -PassThru;'
+          powershell.exe 'curl http://ftp.gnu.org/gnu/aspell/w32/Aspell-0-50-3-3-Setup.exe -o aspell-installer.exe;
+            curl http://ftp.gnu.org/gnu/aspell/w32/Aspell-en-0.50-2-3.exe -o aspell-en-dict.exe;
+            Start-Process -Wait -FilePath .\aspell-installer.exe -Argument "/silent" -PassThru;
+            Start-Process -Wait -FilePath .\aspell-en-dict.exe -Argument "/silent" -PassThru;'
 
           echo "C:\Program Files (x86)\Aspell\bin" >> $GITHUB_PATH
           echo "C:\Program Files (x86)\Aspell\dict" >> $GITHUB_PATH

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,7 +27,7 @@ jobs:
         elif [[ "$RUNNER_OS" == "macOS" ]]; then
           brew install aspell
         elif [[ "$RUNNER_OS" == "Windows" ]]; then
-          choco install aspell
+          pacman -S aspell
         fi
 
     - name: Setup PHP

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,6 +19,16 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v3
 
+    - name: Install Aspell (Ubuntu, macOS, Windows)
+      run: |
+        if [[ "$RUNNER_OS" == "Linux" ]]; then
+          sudo apt-get update && sudo apt-get install -y aspell aspell-en
+        elif [[ "$RUNNER_OS" == "macOS" ]]; then
+          brew install aspell
+        elif [[ "$RUNNER_OS" == "Windows" ]]; then
+          choco install aspell
+        fi
+
     - name: Setup PHP
       uses: shivammathur/setup-php@v2
       with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,10 +30,8 @@ jobs:
           powershell.exe 'curl http://ftp.gnu.org/gnu/aspell/w32/Aspell-0-50-3-3-Setup.exe -o aspell-installer.exe;
             Start-Process -Wait -FilePath .\aspell-installer.exe -Argument "/silent" -PassThru;'
           powershell.exe 'curl http://ftp.gnu.org/gnu/aspell/w32/Aspell-en-0.50-2-3.exe -o aspell-en-dict.exe;
-            unzip aspell-en-dict.exe; Start-Process -Wait -FilePath .\TmpInstall\setup-Aspell-en-0.50-2.exe -Argument "/silent" -PassThru;
+            unzip aspell-en-dict.exe; Start-Process -Wait -FilePath .\TmpInstall\setup-Aspell-en-0.50-2.exe -Argument "/silent" -PassThru;''
 
-          echo "File Output:"
-          cat aspell_en_dict_log.txt
           ls -l 'C:\Program Files (x86)\Aspell'
           echo "C:\Program Files (x86)\Aspell\bin" >> $GITHUB_PATH
           echo "C:\Program Files (x86)\Aspell\dict" >> $GITHUB_PATH

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,9 +32,9 @@ jobs:
             Start-Process -Wait -FilePath .\aspell-installer.exe -Argument "/silent" -PassThru;
             Start-Process -Wait -FilePath .\aspell-en-dict.exe -Argument "/silent" -PassThru;'
 
+          ls -l 'C:\Program Files (x86)\Aspell'
           echo "C:\Program Files (x86)\Aspell\bin" >> $GITHUB_PATH
           echo "C:\Program Files (x86)\Aspell\dict" >> $GITHUB_PATH
-          ls -l 'C:\Program Files (x86)\Aspell\dict'
         fi
 
     - name: Test Aspell

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,7 +27,9 @@ jobs:
         elif [[ "$RUNNER_OS" == "macOS" ]]; then
           brew install aspell
         elif [[ "$RUNNER_OS" == "Windows" ]]; then
-          pacman -S aspell
+          curl http://ftp.gnu.org/gnu/aspell/w32/Aspell-0-50-3-3-Setup.exe -o aspell-installer.exe
+          powershell.exe 'Start-Process -Wait -FilePath .\aspell-installer.exe -Argument "/silent" -PassThru'
+          export PATH=$PATH:"/c/Program Files (x86)/Aspell/bin"
         fi
 
     - name: Setup PHP

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,15 +32,10 @@ jobs:
           powershell.exe 'curl http://ftp.gnu.org/gnu/aspell/w32/Aspell-en-0.50-2-3.exe -o aspell-en-dict.exe;
             unzip aspell-en-dict.exe; Start-Process -Wait -FilePath .\TmpInstall\setup-Aspell-en-0.50-2.exe -Argument "/silent" -PassThru;'
 
-          ls -l 'C:\Program Files (x86)\Aspell'
           echo "C:\Program Files (x86)\Aspell\bin" >> $GITHUB_PATH
           echo "C:\Program Files (x86)\Aspell\dict" >> $GITHUB_PATH
         fi
-
-    - name: Test Aspell
-      shell: bash
-      run: ls -l 'C:\Program Files (x86)\Aspell\dict' || true; aspell --version; echo "This is a smaple text with some mispelled words" | aspell --encoding=utf-8 -a
-
+        aspell --version
     - name: Setup PHP
       uses: shivammathur/setup-php@v2
       with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,7 +35,6 @@ jobs:
           echo "C:\Program Files (x86)\Aspell\bin" >> $GITHUB_PATH
           echo "C:\Program Files (x86)\Aspell\dict" >> $GITHUB_PATH
         fi
-        aspell --version
     - name: Setup PHP
       uses: shivammathur/setup-php@v2
       with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,7 +39,7 @@ jobs:
 
     - name: Test Aspell
       shell: bash
-      run: ls -l 'C:\Program Files (x86)\Aspell\dict'; aspell --version; echo "This is a smaple text with some mispelled words" | aspell --encoding=utf-8 -a
+      run: ls -l 'C:\Program Files (x86)\Aspell\dict' || true; aspell --version; echo "This is a smaple text with some mispelled words" | aspell --encoding=utf-8 -a
 
     - name: Setup PHP
       uses: shivammathur/setup-php@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,7 +30,7 @@ jobs:
           powershell.exe 'curl http://ftp.gnu.org/gnu/aspell/w32/Aspell-0-50-3-3-Setup.exe -o aspell-installer.exe;
             Start-Process -Wait -FilePath .\aspell-installer.exe -Argument "/silent" -PassThru;'
           powershell.exe 'curl http://ftp.gnu.org/gnu/aspell/w32/Aspell-en-0.50-2-3.exe -o aspell-en-dict.exe;
-            Start-Process -Wait -FilePath .\aspell-en-dict.exe -Argument "/silent" -PassThru | Out-File aspell_en_dict_log.txt;'
+            unzip aspell-en-dict.exe; Start-Process -Wait -FilePath .\TmpInstall\setup-Aspell-en-0.50-2.exe -Argument "/silent" -PassThru;
 
           echo "File Output:"
           cat aspell_en_dict_log.txt

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,6 +34,7 @@ jobs:
             $currentPath = [Environment]::GetEnvironmentVariable("Path", [EnvironmentVariableTarget]::User);
             [Environment]::SetEnvironmentVariable("Path", $currentPath + ";C:\Program Files (x86)\Aspell\bin", [EnvironmentVariableTarget]::User);'
         fi
+        echo "This is a smaple text with some mispelled words" | aspell --encoding=utf-8 -a
 
     - name: Setup PHP
       uses: shivammathur/setup-php@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,8 +28,8 @@ jobs:
           brew install aspell
         elif [[ "$RUNNER_OS" == "Windows" ]]; then
           powershell.exe 'curl http://ftp.gnu.org/gnu/aspell/w32/Aspell-0-50-3-3-Setup.exe -o aspell-installer.exe;
-            curl http://ftp.gnu.org/gnu/aspell/w32/Aspell-en-0.50-2-3.exe -o aspell-en-dict.exe;
-            Start-Process -Wait -FilePath .\aspell-installer.exe -Argument "/silent" -PassThru;
+            Start-Process -Wait -FilePath .\aspell-installer.exe -Argument "/silent" -PassThru;'
+          powershell.exe 'curl http://ftp.gnu.org/gnu/aspell/w32/Aspell-en-0.50-2-3.exe -o aspell-en-dict.exe;
             Start-Process -Wait -FilePath .\aspell-en-dict.exe -Argument "/silent" -PassThru;'
 
           ls -l 'C:\Program Files (x86)\Aspell'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest]
         php: ['8.3', '8.4']
         dependency-version: [prefer-lowest, prefer-stable]
 
@@ -19,21 +19,13 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v3
 
-    - name: Install Aspell (Ubuntu, macOS, Windows)
+    - name: Install Aspell
       shell: bash
       run: |
         if [[ "$RUNNER_OS" == "Linux" ]]; then
           sudo apt-get update && sudo apt-get install -y aspell aspell-en
         elif [[ "$RUNNER_OS" == "macOS" ]]; then
           brew install aspell
-        elif [[ "$RUNNER_OS" == "Windows" ]]; then
-          powershell.exe 'curl http://ftp.gnu.org/gnu/aspell/w32/Aspell-0-50-3-3-Setup.exe -o aspell-installer.exe;
-            Start-Process -Wait -FilePath .\aspell-installer.exe -Argument "/silent" -PassThru;'
-          powershell.exe 'curl http://ftp.gnu.org/gnu/aspell/w32/Aspell-en-0.50-2-3.exe -o aspell-en-dict.exe;
-            unzip aspell-en-dict.exe; Start-Process -Wait -FilePath .\TmpInstall\setup-Aspell-en-0.50-2.exe -Argument "/silent" -PassThru;'
-
-          echo "C:\Program Files (x86)\Aspell\bin" >> $GITHUB_PATH
-          echo "C:\Program Files (x86)\Aspell\dict" >> $GITHUB_PATH
         fi
     - name: Setup PHP
       uses: shivammathur/setup-php@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,9 +27,10 @@ jobs:
         elif [[ "$RUNNER_OS" == "macOS" ]]; then
           brew install aspell
         elif [[ "$RUNNER_OS" == "Windows" ]]; then
-          curl http://ftp.gnu.org/gnu/aspell/w32/Aspell-0-50-3-3-Setup.exe -o aspell-installer.exe
-          powershell.exe 'Start-Process -Wait -FilePath .\aspell-installer.exe -Argument "/silent" -PassThru'
-          export PATH=$PATH:"/c/Program Files (x86)/Aspell/bin"
+          powershell.exe 'curl http://ftp.gnu.org/gnu/aspell/w32/Aspell-0-50-3-3-Setup.exe -o aspell-installer.exe;
+            Start-Process -Wait -FilePath .\aspell-installer.exe -Argument "/silent" -PassThru;
+            $currentPath = [Environment]::GetEnvironmentVariable("Path", [EnvironmentVariableTarget]::User);
+            [Environment]::SetEnvironmentVariable("Path", $currentPath + ";C:\Program Files (x86)\Aspell\bin", [EnvironmentVariableTarget]::User);'
         fi
 
     - name: Setup PHP

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,7 +30,7 @@ jobs:
           powershell.exe 'curl http://ftp.gnu.org/gnu/aspell/w32/Aspell-0-50-3-3-Setup.exe -o aspell-installer.exe;
             Start-Process -Wait -FilePath .\aspell-installer.exe -Argument "/silent" -PassThru;'
           powershell.exe 'curl http://ftp.gnu.org/gnu/aspell/w32/Aspell-en-0.50-2-3.exe -o aspell-en-dict.exe;
-            unzip aspell-en-dict.exe; Start-Process -Wait -FilePath .\TmpInstall\setup-Aspell-en-0.50-2.exe -Argument "/silent" -PassThru;''
+            unzip aspell-en-dict.exe; Start-Process -Wait -FilePath .\TmpInstall\setup-Aspell-en-0.50-2.exe -Argument "/silent" -PassThru;'
 
           ls -l 'C:\Program Files (x86)\Aspell'
           echo "C:\Program Files (x86)\Aspell\bin" >> $GITHUB_PATH


### PR DESCRIPTION

### What:

- [X] Bug Fix
- [ ] New Feature

### Description:
With this pull request, I aimed to fix the failing integration tests due to a missing Aspell installation on the action worker. 
As you can see from the commit history, installing it on Windows proves rather challenging...

As you can see from the website [http://aspell.net/](http://aspell.net/) they no longer provide a Windows port, but you can use it through MSYS2. In this pull request I managed to install the legacy Windows port. 

The only problem with this is that the other OS install **Aspell 0.60.8** and the legacy Windows Port uses **Aspell 0.50.3**.
This results in the Testsuite failing, as the suggestions seem to be different in the older language set...

**At this point I am open to feedback on how we should continue: I see the following options:**
1. Mock the Aspell `InMemorySpellchecker` so we can ignore the requirement on the OS.
2. Try to install it on the Action runner using MSYS2 to have the current version.
3. Change the test suite to still work even for different results from aspell