### PR TITLE
Feature/add word to whitelist command

### DIFF
--- a/bin/peck
+++ b/bin/peck
@@ -3,28 +3,37 @@
 
 declare(strict_types=1);
 
+use Peck\Kernel;
 use Symfony\Component\Console\Application;
 
-$vendorPath = dirname(__DIR__, 4).'/vendor/autoload.php';
-$localPath = dirname(__DIR__).'/vendor/autoload.php';
+$possibleAutoloadPaths = [
+    // Local dev repository
+    __DIR__ . '/../vendor/autoload.php',
+    // Composer global installation
+    __DIR__ . '/../../../autoload.php',
+];
 
-if (file_exists($vendorPath)) {
-    include_once $vendorPath;
-    $autoloadPath = $vendorPath;
-} else {
-    include_once $localPath;
-    $autoloadPath = $localPath;
+$autoloadPath = null;
+foreach ($possibleAutoloadPaths as $path) {
+    if (file_exists($path)) {
+        $autoloadPath = $path;
+        break;
+    }
 }
 
-$application = new Application(
-    'Peck',
-    '0.0.1',
-);
+if ($autoloadPath === null) {
+    fwrite(STDERR, 'Cannot find autoload.php. Please run composer install.' . PHP_EOL);
+    exit(1);
+}
 
-$application->add(
-    new \Peck\Console\Commands\DefaultCommand(),
-);
+require $autoloadPath;
 
-$application->setDefaultCommand('default');
+$application = new Application('Peck - Spell Checker');
+$kernel = Kernel::default();
+
+// Register all commands from the kernel
+foreach ($kernel->getCommands() as $command) {
+    $application->add($command);
+}
 
 $application->run();

--- a/src/Console/Commands/WhitelistCommand.php
+++ b/src/Console/Commands/WhitelistCommand.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Peck\Console\Commands;
+
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Output\OutputInterface;
+use Peck\Services\WhitelistManager;
+
+/**
+ * @internal
+ */
+#[AsCommand(name: 'whitelist:add')]
+class WhitelistCommand extends Command
+{
+    public function __construct(
+        private readonly WhitelistManager $whitelistManager
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->setDescription('Add a word to the spelling whitelist')
+            ->addArgument(
+                'word',
+                InputArgument::REQUIRED,
+                'The word to whitelist'
+            );
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $word = strtolower($input->getArgument('word'));
+
+        $this->whitelistManager->add($word);
+
+        $output->writeln("<info>Successfully added '{$word}' to whitelist</info>");
+
+        return Command::SUCCESS;
+    }
+}

--- a/src/Kernel.php
+++ b/src/Kernel.php
@@ -5,7 +5,11 @@ declare(strict_types=1);
 namespace Peck;
 
 use Peck\Checkers\FileSystemChecker;
+use Peck\Console\Commands\DefaultCommand;
+use Peck\Console\Commands\WhitelistCommand;
 use Peck\Services\Spellcheckers\InMemorySpellchecker;
+use Peck\Services\WhitelistManager;
+use Symfony\Component\Console\Command\Command;
 
 final readonly class Kernel
 {
@@ -13,9 +17,11 @@ final readonly class Kernel
      * Creates a new instance of Kernel.
      *
      * @param  array<int, Contracts\Checker>  $checkers
+     * @param  array<int, Command>  $commands
      */
     public function __construct(
         private array $checkers,
+        private array $commands = [],
     ) {
         //
     }
@@ -25,11 +31,16 @@ final readonly class Kernel
      */
     public static function default(): self
     {
+        $whitelistManager = new WhitelistManager(getcwd());
         $inMemoryChecker = InMemorySpellchecker::default();
 
         return new self(
-            [
+            checkers: [
                 new FileSystemChecker($inMemoryChecker),
+            ],
+            commands: [
+                new DefaultCommand(),
+                new WhitelistCommand($whitelistManager),
             ],
         );
     }
@@ -52,5 +63,15 @@ final readonly class Kernel
         }
 
         return $issues;
+    }
+
+    /**
+     * Get all registered commands.
+     *
+     * @return array<int, Command>
+     */
+    public function getCommands(): array
+    {
+        return $this->commands;
     }
 }

--- a/src/Services/Spellcheckers/InMemorySpellchecker.php
+++ b/src/Services/Spellcheckers/InMemorySpellchecker.php
@@ -12,12 +12,19 @@ use PhpSpellcheck\Spellchecker\Aspell;
 
 final readonly class InMemorySpellchecker implements Spellchecker
 {
+     /**
+     * Creates a new instance of Spellchecker.
+     */
     public function __construct(
         private Aspell $aspell,
         private WhitelistManager $whitelistManager,
     ) {
+        //
     }
-
+    
+    /**
+     * Creates the default instance of Spellchecker.
+     */
     public static function default(): self
     {
         return new self(
@@ -25,7 +32,12 @@ final readonly class InMemorySpellchecker implements Spellchecker
             new WhitelistManager(getcwd())
         );
     }
-
+    
+    /**
+     * Checks of issues in the given text.
+     *
+     * @return array<int, Misspelling>
+     */
     public function check(string $text): array
     {
         $misspellings = $this->aspell->check($text);

--- a/src/Services/Spellcheckers/InMemorySpellchecker.php
+++ b/src/Services/Spellcheckers/InMemorySpellchecker.php
@@ -5,43 +5,40 @@ declare(strict_types=1);
 namespace Peck\Services\Spellcheckers;
 
 use Peck\Contracts\Services\Spellchecker;
+use Peck\Services\WhitelistManager;
 use Peck\ValueObjects\Misspelling;
 use PhpSpellcheck\MisspellingInterface;
 use PhpSpellcheck\Spellchecker\Aspell;
 
 final readonly class InMemorySpellchecker implements Spellchecker
 {
-    /**
-     * Creates a new instance of Spellchecker.
-     */
     public function __construct(
         private Aspell $aspell,
+        private WhitelistManager $whitelistManager,
     ) {
-        //
     }
 
-    /**
-     * Creates the default instance of Spellchecker.
-     */
     public static function default(): self
     {
         return new self(
             Aspell::create(),
+            new WhitelistManager(getcwd())
         );
     }
 
-    /**
-     * Checks of issues in the given text.
-     *
-     * @return array<int, Misspelling>
-     */
     public function check(string $text): array
     {
         $misspellings = $this->aspell->check($text);
 
-        return array_map(fn (MisspellingInterface $misspelling): Misspelling => new Misspelling(
+        return array_values(array_filter(
+            array_map(
+                fn (MisspellingInterface $misspelling): Misspelling => new Misspelling(
             $misspelling->getWord(),
             array_slice($misspelling->getSuggestions(), 0, 4),
-        ), iterator_to_array($misspellings));
+                ),
+                iterator_to_array($misspellings)
+            ),
+            fn (Misspelling $misspelling): bool => !$this->whitelistManager->isWhitelisted($misspelling->word)
+        ));
     }
 }

--- a/src/Services/WhitelistManager.php
+++ b/src/Services/WhitelistManager.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Peck\Services;
+
+/**
+ * @internal
+ */
+final readonly class WhitelistManager
+{
+    private const WHITELIST_FILE = '.peck-whitelist.json';
+
+    public function __construct(
+        private string $baseDirectory
+    ) {
+    }
+
+    /**
+     * Add a word to the whitelist
+     */
+    public function add(string $word): void
+    {
+        $whitelist = $this->load();
+
+        if (!in_array($word, $whitelist, true)) {
+            $whitelist[] = $word;
+            $this->save($whitelist);
+        }
+    }
+
+    /**
+     * Check if a word is whitelisted
+     */
+    public function isWhitelisted(string $word): bool
+    {
+        return in_array(strtolower($word), $this->load(), true);
+    }
+
+    /**
+     * Load the whitelist from storage
+     *
+     * @return array<int, string>
+     */
+    private function load(): array
+    {
+        $path = $this->getWhitelistPath();
+
+        if (!file_exists($path)) {
+            return [];
+        }
+
+        $content = file_get_contents($path);
+
+        return json_decode($content, true) ?? [];
+    }
+
+    /**
+     * Save the whitelist to storage
+     *
+     * @param array<int, string> $whitelist
+     */
+    private function save(array $whitelist): void
+    {
+        file_put_contents(
+            $this->getWhitelistPath(),
+            json_encode($whitelist, JSON_PRETTY_PRINT)
+        );
+    }
+
+    private function getWhitelistPath(): string
+    {
+        return $this->baseDirectory . DIRECTORY_SEPARATOR . self::WHITELIST_FILE;
+    }
+}


### PR DESCRIPTION
### What:
- [x] New Feature

### Description:
This PR adds a whitelist command functionality to Peck, allowing users to specify words that should be ignored by the spell checker. This is particularly useful for:
- Technical terms
- Project-specific terminology
- Company/product names

Features added:
- New `whitelist:add` command
- Persistent storage of whitelisted words in `.peck-whitelist.json`
- Integration with existing spell checker to ignore whitelisted words
- WhitelistManager service for handling whitelist operations

Usage:
```bash
./peck whitelist:add <word>