### PR TITLE
Add Method Name Checker

### DIFF
--- a/peck.json
+++ b/peck.json
@@ -1,7 +1,8 @@
 {
     "ignore": {
         "words": [
-            "config"
+            "config",
+            "php"
         ],
         "directories": []
     }

--- a/src/Checkers/MethodNameChecker.php
+++ b/src/Checkers/MethodNameChecker.php
@@ -92,18 +92,16 @@ readonly class MethodNameChecker implements Checker
 
     /**
      * Prepares the method name for spellchecking.
-     * e.g. ‘getHTTPClient‘ -> 'get http client'
+     * e.g. 'camelCase' -> 'camel case'
+     * e.g. 'snake_case' -> 'snake case'
      * e.g. '__construct' -> 'construct'
      */
     private function prepareMethodName(string $methodName): string
     {
-        return strtolower(
-            (string) \preg_replace(
-                '/(?<!^)[A-Z]/',
-                ' $0',
-                (string) \preg_replace('/[^a-zA-Z0-9]/', '', $methodName)
-            )
-        );
+        $formatted = preg_replace('/([a-z0-9])([A-Z])/', '$1 $2', $methodName);
+        $formatted = str_replace('_', ' ', $formatted);
+
+        return strtolower(trim($formatted));
     }
 
     /**

--- a/src/Checkers/MethodNameChecker.php
+++ b/src/Checkers/MethodNameChecker.php
@@ -58,6 +58,8 @@ readonly class MethodNameChecker implements Checker
             }
         }
 
+        usort($issues, fn (Issue $a, Issue $b): int => $a->file <=> $b->file);
+
         return $issues;
     }
 

--- a/src/Checkers/MethodNameChecker.php
+++ b/src/Checkers/MethodNameChecker.php
@@ -1,0 +1,121 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Peck\Checkers;
+
+use Iterator;
+use Peck\Config;
+use Peck\Contracts\Checker;
+use Peck\Contracts\Services\Spellchecker;
+use Peck\ValueObjects\Issue;
+use Peck\ValueObjects\Misspelling;
+use SplFileInfo;
+use Symfony\Component\Finder\Finder;
+
+/**
+ * @internal
+ */
+readonly class MethodNameChecker implements Checker
+{
+    /**
+     * Creates a new instance of FsChecker.
+     */
+    public function __construct(
+        private Config $config,
+        private Spellchecker $spellchecker,
+    ) {
+        //
+    }
+
+    /**
+     * Checks for issues in the given directory.
+     *
+     * @param  array<string, string>  $parameters
+     * @return array<int, Issue>
+     */
+    public function check(array $parameters): array
+    {
+        $files = $this->getPhpFiles($parameters['directory']);
+
+        $issues = [];
+
+        foreach ($files as $file) {
+            $methods = $this->getMethodDeclarations($file);
+
+            foreach ($methods as $method) {
+                $issues = [
+                    ...$issues,
+                    ...array_map(
+                        fn (Misspelling $misspelling): Issue => new Issue(
+                            $misspelling,
+                            $file->getRealPath(),
+                            $method['line'],
+                        ),
+                        $this->spellchecker->check($method['name'])
+                    ),
+                ];
+            }
+        }
+
+        return $issues;
+    }
+
+    /**
+     * Retrieves all method declarations in the given file.
+     * Uses a simple regex to find method declarations.
+     *
+     * @return array{name: string, line: int}[]
+     */
+    private function getMethodDeclarations(SplFileInfo $file): array
+    {
+        $content = file_get_contents($file->getRealPath());
+
+        if ($content === false) {
+            return [];
+        }
+
+        $matches = [];
+        \preg_match_all('/function\s+([a-zA-Z0-9_]+)\s*\(/m', $content, $matches, PREG_OFFSET_CAPTURE);
+
+        return array_map(function (array $match) use ($content): array {
+            $method = \ltrim($match[0], '__');
+
+            return [
+                'name' => $this->prepareMethodName($method),
+                'line' => substr_count(substr($content, 0, $match[1]), "\n") + 1,
+            ];
+        }, $matches[1]);
+    }
+
+    /**
+     * Prepares the method name for spellchecking.
+     * e.g. ‘getHTTPClient‘ -> 'get http client'
+     * e.g. '__construct' -> 'construct'
+     */
+    private function prepareMethodName(string $methodName): string
+    {
+        return strtolower(
+            (string) \preg_replace(
+                '/(?<!^)[A-Z]/',
+                ' $0',
+                (string) \preg_replace('/[^a-zA-Z0-9]/', '', $methodName)
+            )
+        );
+    }
+
+    /**
+     * Fetches all PHP files in the given directory.
+     *
+     * @return Iterator<string, SplFileInfo>
+     */
+    private function getPhpFiles(string $directory): Iterator
+    {
+        return Finder::create()
+            ->notPath($this->config->whitelistedDirectories)
+            ->ignoreUnreadableDirs()
+            ->in($directory)
+            ->name('*.php')
+            ->getIterator();
+    }
+}

--- a/src/Checkers/MethodNameChecker.php
+++ b/src/Checkers/MethodNameChecker.php
@@ -99,7 +99,7 @@ readonly class MethodNameChecker implements Checker
     private function prepareMethodName(string $methodName): string
     {
         $formatted = preg_replace('/([a-z0-9])([A-Z])/', '$1 $2', $methodName);
-        $formatted = str_replace('_', ' ', $formatted);
+        $formatted = str_replace('_', ' ', (string) $formatted);
 
         return strtolower(trim($formatted));
     }

--- a/src/Kernel.php
+++ b/src/Kernel.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Peck;
 
 use Peck\Checkers\FileSystemChecker;
+use Peck\Checkers\MethodNameChecker;
 use Peck\Services\Spellcheckers\InMemorySpellchecker;
 
 final readonly class Kernel
@@ -31,6 +32,7 @@ final readonly class Kernel
         return new self(
             [
                 new FileSystemChecker($config, $inMemoryChecker),
+                new MethodNameChecker($config, $inMemoryChecker),
             ],
         );
     }

--- a/tests/Fixtures/FolderWithTypoos/FileWithMethodTypos.php
+++ b/tests/Fixtures/FolderWithTypoos/FileWithMethodTypos.php
@@ -1,0 +1,14 @@
+<?php
+
+class FileWithMethodTypos
+{
+    public function thisIsSpellledWrong(): void
+    {
+        //
+    }
+}
+
+function thisFunctionIsSpellledWrong(): void
+{
+    //
+}

--- a/tests/Fixtures/FolderWithTypoos/FolderThatShouldBeIgnored/FileThatShoudBeIgnoredBecauseItsInsideWhitelistedFolder.php
+++ b/tests/Fixtures/FolderWithTypoos/FolderThatShouldBeIgnored/FileThatShoudBeIgnoredBecauseItsInsideWhitelistedFolder.php
@@ -1,3 +1,7 @@
 <?php
 
 //
+function anotherFunctionWithSpelllingMistake(): void
+{
+    //
+}

--- a/tests/Unit/Checkers/MethodNameChecker.php
+++ b/tests/Unit/Checkers/MethodNameChecker.php
@@ -1,0 +1,126 @@
+<?php
+
+use Peck\Checkers\MethodNameChecker;
+use Peck\Config;
+use Peck\Services\Spellcheckers\InMemorySpellchecker;
+use PhpSpellcheck\Spellchecker\Aspell;
+
+it('does not detect issues in the given directory', function (): void {
+    $checker = new MethodNameChecker(
+        Config::instance(),
+        InMemorySpellchecker::default(),
+    );
+
+    $issues = $checker->check([
+        'directory' => __DIR__.'/../../../src',
+    ]);
+
+    expect($issues)->toBeEmpty();
+});
+
+it('detects issues in the given directory', function (): void {
+    $checker = new MethodNameChecker(
+        Config::instance(),
+        InMemorySpellchecker::default(),
+    );
+
+    $issues = $checker->check([
+        'directory' => __DIR__.'/../../Fixtures',
+    ]);
+
+    expect($issues)->toHaveCount(3)
+        ->and($issues[0]->file)->toEndWith('tests/Fixtures/FolderWithTypoos/FileWithMethodTypos.php')
+        ->and($issues[0]->line)->toBe(5)
+        ->and($issues[0]->misspelling->word)->toBe('spellled')
+        ->and($issues[0]->misspelling->suggestions)->toBe([
+            'spelled',
+            'spilled',
+            'spell led',
+            'spell-led',
+        ])->and($issues[1]->file)->toEndWith('tests/Fixtures/FolderWithTypoos/FileWithMethodTypos.php')
+        ->and($issues[1]->line)->toBe(11)
+        ->and($issues[1]->misspelling->word)->toBe('spellled')
+        ->and($issues[1]->misspelling->suggestions)->toBe([
+            'spelled',
+            'spilled',
+            'spell led',
+            'spell-led',
+        ])->and($issues[2]->file)->toEndWith('tests/Fixtures/FolderWithTypoos/FolderThatShouldBeIgnored/FileThatShoudBeIgnoredBecauseItsInsideWhitelistedFolder.php')
+        ->and($issues[2]->line)->toBe(4)
+        ->and($issues[2]->misspelling->word)->toBe('spellling')
+        ->and($issues[2]->misspelling->suggestions)->toBe([
+            'spelling',
+            'spilling',
+            'spell ling',
+            'spell-ling',
+        ]);
+});
+
+it('detects issues in the given directory, but ignores the whitelisted words', function (): void {
+    $config = new Config(
+        whitelistedWords: ['spellling'],
+    );
+
+    $checker = new MethodNameChecker(
+        $config,
+        new InMemorySpellchecker(
+            $config,
+            Aspell::create(),
+        ),
+    );
+
+    $issues = $checker->check([
+        'directory' => __DIR__.'/../../Fixtures',
+    ]);
+
+    expect($issues)->toHaveCount(2)
+        ->and($issues[0]->file)->toEndWith('tests/Fixtures/FolderWithTypoos/FileWithMethodTypos.php')
+        ->and($issues[0]->line)->toBe(5)
+        ->and($issues[0]->misspelling->word)->toBe('spellled')
+        ->and($issues[0]->misspelling->suggestions)->toBe([
+            'spelled',
+            'spilled',
+            'spell led',
+            'spell-led',
+        ])->and($issues[1]->file)->toEndWith('tests/Fixtures/FolderWithTypoos/FileWithMethodTypos.php')
+        ->and($issues[1]->line)->toBe(11)
+        ->and($issues[1]->misspelling->word)->toBe('spellled')
+        ->and($issues[1]->misspelling->suggestions)->toBe([
+            'spelled',
+            'spilled',
+            'spell led',
+            'spell-led',
+        ]);
+});
+
+it('detects issues in the given directory, but ignores the whitelisted directories', function (): void {
+    $checker = new MethodNameChecker(
+        new Config(
+            whitelistedDirectories: ['FolderThatShouldBeIgnored'],
+        ),
+        InMemorySpellchecker::default(),
+    );
+
+    $issues = $checker->check([
+        'directory' => __DIR__.'/../../Fixtures',
+    ]);
+
+    expect($issues)->toHaveCount(2)
+        ->and($issues[0]->file)->toEndWith('tests/Fixtures/FolderWithTypoos/FileWithMethodTypos.php')
+        ->and($issues[0]->line)->toBe(5)
+        ->and($issues[0]->misspelling->word)->toBe('spellled')
+        ->and($issues[0]->misspelling->suggestions)->toBe([
+            'spelled',
+            'spilled',
+            'spell led',
+            'spell-led',
+        ])->and($issues[1]->file)->toEndWith('tests/Fixtures/FolderWithTypoos/FileWithMethodTypos.php')
+        ->and($issues[1]->line)->toBe(11)
+        ->and($issues[1]->misspelling->word)->toBe('spellled')
+        ->and($issues[1]->misspelling->suggestions)->toBe([
+            'spelled',
+            'spilled',
+            'spell led',
+            'spell-led',
+        ]);
+});

--- a/tests/Unit/ConfigTest.php
+++ b/tests/Unit/ConfigTest.php
@@ -5,7 +5,7 @@ use Peck\Config;
 it('should have a default configuration', function (): void {
     $config = Config::instance();
 
-    expect($config->whitelistedWords)->toBe(['config'])
+    expect($config->whitelistedWords)->toBe(['config', 'php'])
         ->and($config->whitelistedDirectories)->toBe([]);
 });
 

--- a/tests/Unit/KernelTest.php
+++ b/tests/Unit/KernelTest.php
@@ -9,5 +9,5 @@ it('handles multiple checkers', function (): void {
         'directory' => __DIR__.'/../Fixtures',
     ]);
 
-    expect($issues)->toHaveCount(4);
+    expect($issues)->toHaveCount(7);
 });


### PR DESCRIPTION
### What:

- [ ] Bug Fix
- [X] New Feature

### Description:

With this pull request, I aimed to add a new checker for method names. 
However, I just saw #17, which does something similar (in a different way).

The main difference is the way we check for the strings. 
This PR uses regex and preg_match_all, while the other PR uses PHP tokenization.

I also tried the approach of using tokenization, but ran into problems with anonymous functions.
Thats why I decided to stick to regex, which seems easier. 

Furthermore, I tried to make the method name extraction a bit more robust to support different naming conventions.

### Related:

Very similar Feature (with different approach): #17 
