### PR TITLE
Feature/ignore word command

### DIFF
--- a/bin/peck
+++ b/bin/peck
@@ -25,6 +25,10 @@ $application->add(
     new \Peck\Console\Commands\DefaultCommand(),
 );
 
+$application->add(
+    new \Peck\Console\Commands\AddIgnoreWordCommand(),
+);
+
 $application->setDefaultCommand('default');
 
 $application->run();

--- a/src/Config.php
+++ b/src/Config.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Peck;
 
 use Composer\Autoload\ClassLoader;
+use InvalidArgumentException;
 
 final class Config
 {
@@ -22,6 +23,7 @@ final class Config
     public function __construct(
         public array $whitelistedWords = [],
         public array $whitelistedDirectories = [],
+        public ?string $configFilePath = null,
     ) {
         $this->whitelistedWords = array_map(fn (string $word): string => strtolower($word), $whitelistedWords);
     }
@@ -29,27 +31,86 @@ final class Config
     /**
      * Fetches the instance of the configuration.
      */
-    public static function instance(): self
+    public static function instance(bool $refresh = false, ?string $configFilePath = null): self
     {
-        if (self::$instance instanceof self) {
+        if (self::$instance instanceof self && ! $refresh) {
             return self::$instance;
+        }
+
+        $config = (new self)->setConfigFilepath($configFilePath)->getConfigAsArray();
+
+        return self::$instance = new self(
+            whitelistedWords: $config['ignore']['words'] ?? [],
+            whitelistedDirectories: $config['ignore']['directories'] ?? [],
+            configFilePath: $configFilePath,
+        );
+    }
+
+    /**
+     * Returns the config filepath.
+     */
+    public function getConfigFilePath(): string
+    {
+        if (! is_null($this->configFilePath) && file_exists($this->configFilePath)) {
+            return $this->configFilePath;
         }
 
         $basePath = dirname(array_keys(ClassLoader::getRegisteredLoaders())[0]);
 
-        $contents = (string) file_get_contents($basePath.'/peck.json');
+        return sprintf('%s/peck.json', $basePath);
+    }
 
-        /** @var array{
-         *     ignore?: array{
-         *         words?: array<int, string>,
-         *         directories?: array<int, string>
-         *     }
-         *  } $jsonAsArray */
-        $jsonAsArray = json_decode($contents, true) ?: [];
+    /**
+     * Returns the config as an array
+     *
+     * @return array{
+     *     ignore?: array{
+     *         words?: array<int, string>,
+     *         directories?: array<int, string>
+     *     }
+     * }
+     */
+    public function getConfigAsArray(): array
+    {
+        $contents = (string) file_get_contents($this->getConfigFilePath());
+        $config = json_decode($contents, true);
 
-        return self::$instance = new self(
-            $jsonAsArray['ignore']['words'] ?? [],
-            $jsonAsArray['ignore']['directories'] ?? [],
-        );
+        if (! is_array($config)) {
+            return [];
+        }
+
+        return $config;
+    }
+
+    /*
+     * Set config values using dot notation for nested array values
+     *
+     * @phpstan-ignore-next-line
+     */
+    public function set(string $dotNotationKey, array $value): void
+    {
+        $config = $this->getConfigAsArray();
+
+        $keys = explode('.', $dotNotationKey);
+
+        $referencedKeyValue = &$config;
+        foreach ($keys as $key) {
+            if (! isset($referencedKeyValue[$key])) {
+                throw new InvalidArgumentException("Cannot set the config value for '{$dotNotationKey}'. The key '{$key}' does not exist in the array.");
+            }
+            /** @phpstan-ignore-next-line */
+            $referencedKeyValue = &$referencedKeyValue[$key];
+        }
+
+        $referencedKeyValue = $value;
+
+        file_put_contents($this->getConfigFilePath(), json_encode($config, JSON_PRETTY_PRINT));
+    }
+
+    private function setConfigFilepath(?string $configFilePath): self
+    {
+        $this->configFilePath = $configFilePath ?? $this->getConfigFilePath();
+
+        return $this;
     }
 }

--- a/src/Console/Commands/AddIgnoreWordCommand.php
+++ b/src/Console/Commands/AddIgnoreWordCommand.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Peck\Console\Commands;
+
+use Peck\Config;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * @codeCoverageIgnore
+ *
+ * @internal
+ */
+#[AsCommand(name: 'ignore')]
+class AddIgnoreWordCommand extends Command
+{
+    /**
+     * Executes the command.
+     */
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        /** @var string $wordInput */
+        $wordInput = $input->getArgument('word');
+        $word = strtolower($wordInput);
+
+        $config = Config::instance();
+
+        if (in_array($word, $config->whitelistedWords, true)) {
+            $output->writeln('');
+            $output->writeln("<info>The word '<error>{$wordInput}</error>' is already in the ignore words list.</info>");
+
+            return Command::FAILURE;
+        }
+
+        $config->set('ignore.words', array_merge($config->whitelistedWords, [$word]));
+
+        $output->writeln("<info>Successfully added '{$wordInput}' to the ignore words list</info>");
+
+        return Command::SUCCESS;
+    }
+
+    /**
+     * Configures the current command.
+     */
+    protected function configure(): void
+    {
+        $this
+            ->setDescription('Add a word to the ignore list config for the spell check process to ignore it.')
+            ->addArgument(
+                name: 'word',
+                mode: InputArgument::REQUIRED,
+                description: 'The word to whitelist'
+            );
+    }
+}

--- a/tests/Fixtures/peck.json
+++ b/tests/Fixtures/peck.json
@@ -1,8 +1,7 @@
 {
     "ignore": {
         "words": [
-            "config",
-            "json"
+            "config"
         ],
         "directories": []
     }

--- a/tests/Fixtures/peck.json.stub
+++ b/tests/Fixtures/peck.json.stub
@@ -1,8 +1,7 @@
 {
     "ignore": {
         "words": [
-            "config",
-            "json"
+            "config"
         ],
         "directories": []
     }

--- a/tests/Unit/Checkers/FileSystemCheckerTest.php
+++ b/tests/Unit/Checkers/FileSystemCheckerTest.php
@@ -66,7 +66,7 @@ it('detects issues in the given directory', function (): void {
 
 it('detects issues in the given directory, but ignores the whitelisted words', function (): void {
     $config = new Config(
-        whitelistedWords: ['Ignroed'],
+        whitelistedWords: ['Ignroed', 'json'],
     );
 
     $checker = new FileSystemChecker(

--- a/tests/Unit/ConfigTest.php
+++ b/tests/Unit/ConfigTest.php
@@ -2,10 +2,18 @@
 
 use Peck\Config;
 
+afterAll(closure: function (): void {
+    $files = glob(__DIR__.'/../Fixtures/peck-*.json') ?: [];
+
+    foreach ($files as $file) {
+        unlink($file);
+    }
+});
+
 it('should have a default configuration', function (): void {
     $config = Config::instance();
 
-    expect($config->whitelistedWords)->toBe(['config'])
+    expect($config->whitelistedWords)->toBe(['config', 'json'])
         ->and($config->whitelistedDirectories)->toBe([]);
 });
 
@@ -15,3 +23,56 @@ it('should to be a singleton', function (): void {
 
     expect($configA)->toBe($configB);
 });
+
+it('returns the peck config file path with relative location', function (): void {
+    $configFilepath = Config::instance()->getConfigFilePath();
+
+    expect($configFilepath)->toBe(dirname(__DIR__, 2).'/peck.json');
+});
+
+it('returns the peck config file path from set value', function (): void {
+    $configFilepath = Config::instance(
+        refresh: true,
+        configFilePath: $testPeck = __DIR__.'/../Fixtures/peck.json.stub'
+    )->getConfigFilePath();
+
+    expect($configFilepath)->toBe($testPeck);
+});
+
+it('returns empty if the config to array method fails', function (): void {
+    touch($emptyJson = __DIR__.'/../Fixtures/peck-empty.json');
+    expect(Config::instance(refresh: true, configFilePath: $emptyJson)->getConfigAsArray())->toBe([]);
+});
+
+it('can set a config variable', function (): void {
+    file_put_contents(
+        filename: $testPeck = __DIR__.'/../Fixtures/peck-'.random_int(1, 10000).'.json',
+        data: file_get_contents(__DIR__.'/../Fixtures/peck.json.stub')
+    );
+
+    $configInstance = Config::instance(
+        refresh: true,
+        configFilePath: $testPeck,
+    );
+    $config = $configInstance->getConfigAsArray();
+
+    expect($config['ignore']['words'])->toBe(['config']);
+
+    $configInstance->set('ignore.words', $expected = ['config', 'http', 'php']);
+
+    $configInstance2 = Config::instance(
+        refresh: true,
+        configFilePath: $testPeck,
+    );
+
+    expect($configInstance->getConfigAsArray()['ignore']['words'])->toBe($expected);
+});
+
+it('throws an exception when trying to set a config value that does not exist', function (): void {
+    $configInstance = Config::instance(
+        refresh: true,
+        configFilePath: __DIR__.'/../Fixtures/peck.json.stub',
+    );
+
+    $configInstance->set('accept.words', $expected = ['config', 'http', 'php']);
+})->throws(InvalidArgumentException::class);


### PR DESCRIPTION
<!--
- Fill in the form below correctly. This will help the Peck team to understand the PR and also work on it.
-->

### What:

New Feature

### Description:

<!-- describe what your PR is solving -->

This is an adaptation of [#14 https://github.com/peckphp/peck/pull/14#issue-2760231601](https://github.com/peckphp/peck/pull/14#issue-2760231601)

Using a new config set method, and utilising the new 'ignore words' terminology, this PR gives peck a new command to add words to the ignore list.

As @peak-flow says in his PR:

> This PR adds a 'Add Ignore Word' command functionality to Peck, allowing users to specify words that should be ignored by the spell checker. This is particularly useful for:
> 
> - Technical terms
> - Project-specific terminology
> - Company/product names

Features added:

 - New ignore <word> command
 - Persistent storage of ignore words in the existing peck.json configuration file
 - Configuration set functionality using dot notation
 - Config get and set config file path for testing

### Related:

[#14 https://github.com/peckphp/peck/pull/14#issue-2760231601](https://github.com/peckphp/peck/pull/14#issue-2760231601)
