### PR TITLE
Fixes the config file "not found" PHP warning

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -36,8 +36,13 @@ final class Config
         }
 
         $basePath = dirname(array_keys(ClassLoader::getRegisteredLoaders())[0]);
+        $configFile = "{$basePath}/peck.json";
 
-        $contents = (string) file_get_contents($basePath.'/peck.json');
+        if ( !file_exists($configFile) ) {
+            $configFile = dirname(__DIR__) . '/peck.json';
+        }
+
+        $contents = (string) file_get_contents($configFile);
 
         /** @var array{
          *     ignore?: array{


### PR DESCRIPTION
<!--
- Fill in the form below correctly. This will help the Peck team to understand the PR and also work on it.
-->

### What:

- [x] Bug Fix

### Description:

Fixes the config file "not found" PHP warning and loads the "peck.json" of src.

It's better to load a default "peck.json" with basic args initially, allowing it to be overridden later using CLI.
