### PR TITLE
Remove ignoreVcs in Finder::check() (tests still pass)

### DIFF
--- a/src/Checkers/FileSystemChecker.php
+++ b/src/Checkers/FileSystemChecker.php
@@ -37,7 +37,6 @@ final readonly class FileSystemChecker implements Checker
         $filesOrDirectories = Finder::create()
             ->notPath($this->config->whitelistedDirectories)
             ->ignoreDotFiles(true)
-            ->ignoreVCS(true)
             ->ignoreUnreadableDirs()
             ->ignoreVCSIgnored(true)
             ->in($parameters['directory'])


### PR DESCRIPTION
### What:

- [ ] Bug Fix
- [ ] New Feature

### Description:

The [Symfony docs](https://symfony.com/doc/current/components/finder.html#version-control-files) for the Finder component says that VCS files are ignored by default.

Pest still passes with the line removed
![image](https://github.com/user-attachments/assets/d6ab84f2-93b0-478a-85a9-b7b2c7f79007)
