### PR TITLE
Extend ClassChecker to check PHP Constants

### DIFF
--- a/src/Checkers/ClassChecker.php
+++ b/src/Checkers/ClassChecker.php
@@ -81,6 +81,7 @@ final readonly class ClassChecker implements Checker
         $namesToCheck = [
             ...$this->getMethodNames($reflectionClass),
             ...$this->getPropertyNames($reflectionClass),
+            ...$this->getConstantNames($reflectionClass),
         ];
 
         if ($docComment = $reflectionClass->getDocComment()) {
@@ -148,6 +149,22 @@ final readonly class ClassChecker implements Checker
             fn (ReflectionParameter $parameter): string => $parameter->getName(),
             $method->getParameters(),
         );
+    }
+
+    /**
+     * Get the constant names and their values contained in the given class.
+     *
+     * @param  ReflectionClass<object> $class
+     * @return array<int, string>
+     */
+    private function getConstantNames(ReflectionClass $class): array
+    {
+        $constants = $class->getConstants();
+
+        return array_values(array_filter([
+            ...array_keys($constants),
+            ...array_values($constants),
+        ], fn (mixed $values): bool => is_string($values)));
     }
 
     /**

--- a/src/Checkers/ClassChecker.php
+++ b/src/Checkers/ClassChecker.php
@@ -154,7 +154,7 @@ final readonly class ClassChecker implements Checker
     /**
      * Get the constant names and their values contained in the given class.
      *
-     * @param  ReflectionClass<object> $class
+     * @param  ReflectionClass<object>  $class
      * @return array<int, string>
      */
     private function getConstantNames(ReflectionClass $class): array


### PR DESCRIPTION
### What:

- [ ] Bug Fix
- [X] New Feature

### Description:

This pull request extends the class checker by a new method to also check class constants and their values.
However event with mistakes like `public const CONSTANT_WITH_TYPO_ERORR = 2;` the checks pass.

This is because snake case is not handled. I added a new parser in #34 which solves this problem!
Therefore I couldn't write effective tests for this feature. Once the Parser is accepted, this can be extend by tests.

### Related:

- #34 
Required to actually write tests for this feature
