### PR TITLE
feat: Add command flags to fix issues (interactively or automatically)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,7 @@
     ],
     "require": {
         "php": "^8.3.0",
+        "laravel/prompts": "^0.3.2",
         "nunomaduro/termwind": "^2.3",
         "symfony/console": "^7.2.1",
         "symfony/finder": "^7.2",

--- a/src/Console/Commands/DefaultCommand.php
+++ b/src/Console/Commands/DefaultCommand.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Peck\Console\Commands;
 
 use Composer\Autoload\ClassLoader;
+use Exception;
 use Peck\Kernel;
 use Peck\ValueObjects\Issue;
 use Symfony\Component\Console\Attribute\AsCommand;
@@ -87,15 +88,80 @@ final class DefaultCommand extends Command
     {
         renderUsing($output);
 
-        $file = str_replace($currentDirectory, '.', $issue->file);
-        $lineInfo = ($issue->line !== 0) ? ":{$issue->line}" : '';
+        $fullPath = $issue->file;
+        $relativePath = str_replace($currentDirectory, '.', $fullPath);
+
+        $column = 0;
+
+        $lineDetails = '';
+        $lineInfo = '';
+
+        $suggestions = $issue->misspelling->suggestions;
+
+        static $lastColumn = [];
+
+        if ($issue->line > 0) {
+            // its a file, work with contents
+            $lines = file($fullPath);
+
+            $lineContent = $lines[$issue->line - 1] ?? '';
+            if ($lineContent === '') {
+                throw (new Exception("Could not read the line {$issue->line} in the file '{$fullPath}'"));
+            }
+
+            $fromColumn = isset($lastColumn[$fullPath][$issue->line][$issue->misspelling->word]) ? $lastColumn[$fullPath][$issue->line][$issue->misspelling->word] + 1 : 0;
+            $column = strpos(strtolower($lineContent), $issue->misspelling->word, $fromColumn);
+            if ($column === 0 || $column === false) {
+                throw (new Exception("Could not find the misspelling '{$issue->misspelling->word}' in the line '{$lineContent}'"));
+            }
+
+            $lineInfo = ":{$issue->line}:$column";
+
+            $capitalized = strtolower($lineContent[$column]) !== $lineContent[$column];
+
+            // termwind "<code>" adds some spaces to the left, plus the space-x-1 of the wrapper div
+            $align_spacer = str_repeat(' ', 6);
+            $spacer = str_repeat('-', $column);
+
+            $lastColumn[$fullPath][$issue->line][$issue->misspelling->word] = $column;
+
+            $lineDetails = <<<HTML
+                <code start-line="{$issue->line}">{$lineContent}</code>
+                <pre class="text-red-500 font-bold">{$align_spacer}{$spacer}^</pre>
+            HTML;
+        } else {
+            // it's a path (directory or file)
+            $fromColumn = isset($lastColumn[$fullPath][$issue->line][$issue->misspelling->word]) ? $lastColumn[$fullPath][$issue->line][$issue->misspelling->word] + 1 : 0;
+            $column = strpos(strtolower($fullPath), $issue->misspelling->word, $fromColumn);
+            if ($column === 0 || $column === false) {
+                throw (new Exception("Could not find the misspelling '{$issue->misspelling->word}' in the path '{$fullPath}'"));
+            }
+
+            $capitalized = strtolower($fullPath[$column]) !== $fullPath[$column];
+
+            // termwind "<code>" adds some spaces to the left, plus the space-x-1 of the wrapper div
+            $spacer = str_repeat('-', $column);
+
+            $lastColumn[$fullPath][$issue->line][$issue->misspelling->word] = $column;
+
+            $lineDetails = <<<HTML
+                <pre class="text-blue-300 font-bold">{$fullPath}</pre>
+                <pre class="text-red-500 font-bold">{$spacer}^</pre>
+            HTML;
+        }
+
+        if ($capitalized) {
+            $suggestions = array_map('ucfirst', $suggestions);
+        }
+
         $suggestions = implode(', ', $issue->misspelling->suggestions);
 
         render(<<<HTML
-            <div class="mx-2 mb-1">
+            <div class="mx-2 mb-2">
                 <div class="space-x-1">
                     <span class="bg-red text-white px-1 font-bold">ISSUE</span>
-                    <span>Misspelling in <strong><a href="{$issue->file}{$lineInfo}">{$file}{$lineInfo}</a></strong>: '<strong>{$issue->misspelling->word}</strong>'</span>
+                    <span>Misspelling in <strong><a href="{$fullPath}{$lineInfo}">{$relativePath}{$lineInfo}</a></strong>: '<strong>{$issue->misspelling->word}</strong>'</span>
+                    {$lineDetails}
                 </div>
 
                 <div class="space-x-1 text-gray-700">

--- a/tests/Unit/FixTest.php
+++ b/tests/Unit/FixTest.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+it('fixes testing class', function (): void {
+    $this->fromFolder = realpath(__DIR__.'/../Fixtures/ClassesToTest');
+    $this->fixedFolder = __DIR__.'/../../src/ClassesToTestFixed';
+
+    mkdir($this->fixedFolder);
+    copy($this->fromFolder.'/ClassWithTypoErrors.php', $this->fixedFolder.'/ClassWithTypoErrors.php');
+
+    $dir = realpath(__DIR__.'/../../');
+    shell_exec("cd {$dir} && ./bin/peck -s");
+
+    $file_contents = file_get_contents($this->fixedFolder.'/ClassWithTypoErrors.php');
+
+    $expected_file_contents = <<<'str_WRAP'
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Fixtures\ClassesToTest;
+
+/**
+ * Class ClassWithTypoErrors
+ *
+ * This class is used to test type errors in class properties, methods, method parameters and class documentation block.
+ *
+ * @internal
+ */
+final class ClassWithTypoErrors
+{
+    public int $propertyWithoutTypoError = 1;
+
+    public int $propertyWithTypoError = 2;
+
+    /**
+     * This is a property with a doc block typo error
+     */
+    public int $propertyWithDocBlockTypoError = 3;
+
+    public function methodWithoutTypoError(): string
+    {
+        return 'This is a method without a typo error';
+    }
+
+    public function methodWithTypoError(): string
+    {
+        return 'This is a method with a typo error';
+    }
+
+    /**
+     * This is a method with a doc block typo error
+     */
+    public function methodWithDocBlockTypoError(): string
+    {
+        return 'This is a method with a doc block typo error';
+    }
+
+    public function methodWithTypoErrorInParameters(string $parameterWithoutTypoError, string $parameterWithTypoError): string
+    {
+        return $parameterWithoutTypoError.$parameterWithTypoErorr.'This is a method with a typo error in parameters';
+    }
+
+    public function methodWithoutTypoErrorInParameters(string $parameterWithoutTypoError): string
+    {
+        return $parameterWithoutTypoError.'This is a method without a typo error in parameters';
+    }
+}
+
+str_WRAP;
+
+    expect($file_contents)->toBe($expected_file_contents);
+
+    unlink($this->fixedFolder.'/ClassWithTypoErrors.php');
+    rmdir($this->fixedFolder);
+});
+
+it('fixes folders', function (): void {
+    $errorFolder = __DIR__.'/../../src/samplFolder';
+    $fixedFolder = __DIR__.'/../../src/sampleFolder';
+
+    mkdir($errorFolder);
+    $dir = realpath(__DIR__.'/../../');
+    shell_exec("cd {$dir} && ./bin/peck -s");
+
+    expect(is_dir($fixedFolder))->toBeTrue();
+    expect(is_dir($errorFolder))->toBeFalse();
+
+    rmdir($fixedFolder);
+});
+
+it('fixes file names', function (): void {
+    $errorFile = __DIR__.'/../../src/samplFile.php';
+    $fixedFile = __DIR__.'/../../src/sampleFile.php';
+
+    touch($errorFile);
+    $dir = realpath(__DIR__.'/../../');
+    shell_exec("cd {$dir} && ./bin/peck -s");
+
+    expect(is_file($fixedFile))->toBeTrue();
+    expect(is_file($errorFile))->toBeFalse();
+
+    unlink($fixedFile);
+});


### PR DESCRIPTION
### What:

- [x] New Feature

### Description:

Here's an attempt to have Peck fix issues in files and paths. This PR adds 2 flags:

- -f / --fix: Uses "suggest" from Laravel Prompts to present the suggestions to the user while allowing them to also type their own

- -s / --first-suggestion: Uses the first suggestion given by the misspelling checker to fix the issues automatically.

Not sure if the way testing is handled is the best course of action, open to ideas.

![PeckFixIssuePR](https://github.com/user-attachments/assets/4febb9f8-07d2-45ad-b36d-6559daa1db61)

### Related:

This PR includes #28, I could remove it if necessary