### PR TITLE
fix: added missing 'check' command name to the docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-
 <p align="center">
     <img src="https://raw.githubusercontent.com/peckphp/peck/main/docs/logo.png" alt="Peck example" height="300">
     <p align="center">
@@ -9,7 +8,8 @@
     </p>
 </p>
 
-------
+---
+
 **Peck** is a powerful CLI tool designed to identify wording or spelling mistakes in your codebase. Built for speed, simplicity, and seamless integration, Peck fits naturally into your workflow, much like tools such as Pint or Pest.
 
 Leveraging the robust capabilities of **[GNU Aspell](https://en.wikipedia.org/wiki/GNU_Aspell)** via the [github.com/tigitz/php-spellchecker](https://github.com/tigitz/php-spellchecker) PHP wrapper, Peck inspects every corner of your codebase — including folder names, file names, method names, comments, and beyond — ensuring your work maintains a high standard of clarity and professionalism.
@@ -41,13 +41,8 @@ Peck can be configured using a `peck.json` file in the root of your project. Her
 ```json
 {
     "ignore": {
-        "words": [
-            "config",
-            "namespace"
-        ],
-        "directories": [
-            "app/MyNamespace"
-        ]
+        "words": ["config", "namespace"],
+        "directories": ["app/MyNamespace"]
     }
 }
 ```
@@ -55,7 +50,7 @@ Peck can be configured using a `peck.json` file in the root of your project. Her
 You can also specify the path to the configuration file using the `--config` option:
 
 ```bash
-./vendor/bin/peck --config relative/path/to/peck.json
+./vendor/bin/peck check --config relative/path/to/peck.json
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Peck can be configured using a `peck.json` file in the root of your project. Her
 You can also specify the path to the configuration file using the `--config` option:
 
 ```bash
-./vendor/bin/peck check --config relative/path/to/peck.json
+./vendor/bin/peck --config relative/path/to/peck.json
 ```
 
 ---

--- a/bin/peck
+++ b/bin/peck
@@ -6,10 +6,12 @@ declare(strict_types=1);
 use Peck\Console\Commands\CheckCommand;
 use Symfony\Component\Console\Application;
 
-foreach ([
-    dirname(__DIR__, 4).'/vendor/autoload.php',
-    dirname(__DIR__).'/vendor/autoload.php',
-] as $autoloadPath) {
+foreach (
+    [
+        dirname(__DIR__, 4) . '/vendor/autoload.php',
+        dirname(__DIR__) . '/vendor/autoload.php',
+    ] as $autoloadPath
+) {
     if (file_exists($autoloadPath)) {
         include_once $autoloadPath;
 
@@ -26,6 +28,6 @@ $application->add(
     new CheckCommand(),
 );
 
-$application->setDefaultCommand('check');
+$application->setDefaultCommand('check', true);
 
 $application->run();


### PR DESCRIPTION
<!--
- Fill in the form below correctly. This will help the Peck team to understand the PR and also work on it.
-->

### What:

- [x] Bug Fix
- [ ] New Feature


### Description:

This is just a minor PR to add missing 'check' command name to the docs.


<img width="874" alt="Screenshot 2025-01-04 at 5 50 26 AM" src="https://github.com/user-attachments/assets/f61b4335-431d-40ca-94cc-8d2d3d5c5c14" />
