### PR TITLE
feature: add language configuration with sensible default

### DIFF
--- a/peck.json
+++ b/peck.json
@@ -10,5 +10,8 @@
             "php"
         ],
         "directories": []
-    }
+    },
+    "languages" : [
+        "en"
+    ]
 }

--- a/peck.json
+++ b/peck.json
@@ -1,4 +1,5 @@
 {
+    "language" : "en",
     "ignore": {
         "words": [
             "config",
@@ -10,8 +11,5 @@
             "php"
         ],
         "directories": []
-    },
-    "languages" : [
-        "en"
-    ]
+    }
 }

--- a/src/Config.php
+++ b/src/Config.php
@@ -24,12 +24,11 @@ final class Config
      *
      * @param  array<int, string>  $whitelistedWords
      * @param  array<int, string>  $whitelistedDirectories
-     * @param  array<int, string>  $languages
      */
     public function __construct(
         public array $whitelistedWords = [],
         public array $whitelistedDirectories = [],
-        public array $languages = [],
+        public ?string $language = null,
     ) {
         $this->whitelistedWords = array_map(fn (string $word): string => strtolower($word), $whitelistedWords);
     }
@@ -72,18 +71,18 @@ final class Config
             : '{}';
 
         /** @var array{
+         *     language?: string,
          *     ignore?: array{
          *         words?: array<int, string>,
          *         directories?: array<int, string>
-         *     },
-         *     languages?: array<int, string>
+         *     }
          *  } $jsonAsArray */
         $jsonAsArray = json_decode($contents, true) ?: [];
 
         return self::$instance = new self(
             $jsonAsArray['ignore']['words'] ?? [],
             $jsonAsArray['ignore']['directories'] ?? [],
-            $jsonAsArray['languages'] ?? [],
+            $jsonAsArray['language'] ?? null,
         );
     }
 }

--- a/src/Config.php
+++ b/src/Config.php
@@ -24,10 +24,12 @@ final class Config
      *
      * @param  array<int, string>  $whitelistedWords
      * @param  array<int, string>  $whitelistedDirectories
+     * @param  array<int, string>  $languages
      */
     public function __construct(
         public array $whitelistedWords = [],
         public array $whitelistedDirectories = [],
+        public array $languages = [],
     ) {
         $this->whitelistedWords = array_map(fn (string $word): string => strtolower($word), $whitelistedWords);
     }
@@ -73,13 +75,15 @@ final class Config
          *     ignore?: array{
          *         words?: array<int, string>,
          *         directories?: array<int, string>
-         *     }
+         *     },
+         *     languages?: array<int, string>
          *  } $jsonAsArray */
         $jsonAsArray = json_decode($contents, true) ?: [];
 
         return self::$instance = new self(
             $jsonAsArray['ignore']['words'] ?? [],
             $jsonAsArray['ignore']['directories'] ?? [],
+            $jsonAsArray['languages'] ?? [],
         );
     }
 }

--- a/src/Services/Spellcheckers/InMemorySpellchecker.php
+++ b/src/Services/Spellcheckers/InMemorySpellchecker.php
@@ -40,7 +40,7 @@ final readonly class InMemorySpellchecker implements Spellchecker
      */
     public function check(string $text): array
     {
-        $misspellings = $this->filterWhitelistedWords(iterator_to_array($this->aspell->check($text, $this->config->languages)));
+        $misspellings = $this->filterWhitelistedWords(iterator_to_array($this->aspell->check($text, array_filter([$this->config->language]))));
 
         return array_map(fn (MisspellingInterface $misspelling): Misspelling => new Misspelling(
             $misspelling->getWord(),

--- a/src/Services/Spellcheckers/InMemorySpellchecker.php
+++ b/src/Services/Spellcheckers/InMemorySpellchecker.php
@@ -40,7 +40,7 @@ final readonly class InMemorySpellchecker implements Spellchecker
      */
     public function check(string $text): array
     {
-        $misspellings = $this->filterWhitelistedWords(iterator_to_array($this->aspell->check($text)));
+        $misspellings = $this->filterWhitelistedWords(iterator_to_array($this->aspell->check($text, $this->config->languages)));
 
         return array_map(fn (MisspellingInterface $misspelling): Misspelling => new Misspelling(
             $misspelling->getWord(),


### PR DESCRIPTION
<!--
- Fill in the form below correctly. This will help the Peck team to understand the PR and also work on it.
-->

### What:

- [ - ] New Feature

### Description:

This enables us to specify the language that is used by Aspell. Where users are using another language, they can specify. Also, Aspell relies on the system locale if this is not set, so the current main branch fails for users without en_US locale

### Related:

See issue #27 
<!-- link to the issue(s) your PR is solving. If it doesn't exist, remove the "Related" section. -->
