### PR TITLE
[Formatter] Rename NameParser to SpellcheckFormatter

### DIFF
--- a/peck.json
+++ b/peck.json
@@ -8,7 +8,8 @@
             "doc",
             "bool",
             "php",
-            "api"
+            "api",
+            "formatter"
         ],
         "directories": []
     }

--- a/src/Checkers/ClassChecker.php
+++ b/src/Checkers/ClassChecker.php
@@ -7,7 +7,7 @@ namespace Peck\Checkers;
 use Peck\Config;
 use Peck\Contracts\Checker;
 use Peck\Contracts\Services\Spellchecker;
-use Peck\Support\NameParser;
+use Peck\Support\SpellcheckFormatter;
 use Peck\ValueObjects\Issue;
 use Peck\ValueObjects\Misspelling;
 use ReflectionClass;
@@ -107,7 +107,7 @@ final readonly class ClassChecker implements Checker
                         $misspelling,
                         $file->getRealPath(),
                         $this->getErrorLine($file, $name),
-                    ), $this->spellchecker->check(NameParser::parse($name))),
+                    ), $this->spellchecker->check(SpellcheckFormatter::format($name))),
             ];
         }
 

--- a/src/Checkers/FileSystemChecker.php
+++ b/src/Checkers/FileSystemChecker.php
@@ -7,7 +7,7 @@ namespace Peck\Checkers;
 use Peck\Config;
 use Peck\Contracts\Checker;
 use Peck\Contracts\Services\Spellchecker;
-use Peck\Support\NameParser;
+use Peck\Support\SpellcheckFormatter;
 use Peck\ValueObjects\Issue;
 use Peck\ValueObjects\Misspelling;
 use Symfony\Component\Finder\Finder;
@@ -45,7 +45,7 @@ final readonly class FileSystemChecker implements Checker
 
         foreach ($filesOrDirectories as $fileOrDirectory) {
             $name = $fileOrDirectory->getFilenameWithoutExtension();
-            $name = NameParser::parse($name);
+            $name = SpellcheckFormatter::format($name);
 
             $issues = [
                 ...$issues,

--- a/src/Support/SpellcheckFormatter.php
+++ b/src/Support/SpellcheckFormatter.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Peck\Support;
 
-final readonly class NameParser
+final readonly class SpellcheckFormatter
 {
     /**
      * Transforms the given input (method or class names) into a

--- a/src/Support/SpellcheckFormatter.php
+++ b/src/Support/SpellcheckFormatter.php
@@ -10,7 +10,7 @@ final readonly class SpellcheckFormatter
      * Transforms the given input (method or class names) into a
      * human-readable format which can be used for spellchecking.
      */
-    public static function parse(string $input): string
+    public static function format(string $input): string
     {
         // Trim leading underscores (e.g. __construct -> construct)
         $input = ltrim($input, '_');

--- a/tests/Unit/ConfigTest.php
+++ b/tests/Unit/ConfigTest.php
@@ -16,6 +16,7 @@ it('should have a default configuration', function (): void {
         'bool',
         'php',
         'api',
+        'formatter',
     ])->and($config->whitelistedDirectories)->toBe([]);
 });
 

--- a/tests/Unit/Support/SpellcheckFormatterTest.php
+++ b/tests/Unit/Support/SpellcheckFormatterTest.php
@@ -2,40 +2,40 @@
 
 declare(strict_types=1);
 
-use Peck\Support\NameParser;
+use Peck\Support\SpellcheckFormatter;
 
 it('can handle pascal case', function (): void {
-    $result = NameParser::parse('MyClassName');
+    $result = SpellcheckFormatter::format('MyClassName');
 
     expect($result)->toBeString()->toBe('my class name');
 });
 
 it('can handle camel case', function (): void {
-    $result = NameParser::parse('myMethodOrVariableName');
+    $result = SpellcheckFormatter::format('myMethodOrVariableName');
 
     expect($result)->toBeString()->toBe('my method or variable name');
 });
 
 it('can handle snake case', function (): void {
-    $result = NameParser::parse('snake_case');
+    $result = SpellcheckFormatter::format('snake_case');
 
     expect($result)->toBeString()->toBe('snake case');
 });
 
 it('can handle screaming snake case', function (): void {
-    $result = NameParser::parse('MY_CLASS_CONSTANT');
+    $result = SpellcheckFormatter::format('MY_CLASS_CONSTANT');
 
     expect($result)->toBeString()->toBe('my class constant');
 });
 
 it('can handle kebab case', function (): void {
-    $result = NameParser::parse('some-endpoint-name');
+    $result = SpellcheckFormatter::format('some-endpoint-name');
 
     expect($result)->toBeString()->toBe('some endpoint name');
 });
 
 it('can handle magic functions', function (): void {
-    $result = NameParser::parse('__construct');
+    $result = SpellcheckFormatter::format('__construct');
 
     expect($result)->toBeString()->toBe('construct');
 });


### PR DESCRIPTION

### What:

- [ ] Bug Fix
- [ ] New Feature
- [X] Refactor

### Description:
As suggested on stream, I changed the name of the class (and function as well).

### Related:
#34 
