### PR TITLE
refactor: remove unnecessary variable in NameParser.php

### DIFF
--- a/src/Support/NameParser.php
+++ b/src/Support/NameParser.php
@@ -22,8 +22,6 @@ final readonly class NameParser
         $input = (string) preg_replace('/([a-z])([A-Z])/', '$1 $2', $input);
 
         // Lowercase the input
-        $input = strtolower($input);
-
-        return $input;
+        return strtolower($input);
     }
 }


### PR DESCRIPTION
<!--
- Fill in the form below correctly. This will help the Peck team to understand the PR and also work on it.
-->

### What:

- [ ] Bug Fix
- [ ] New Feature
- [x] Refactor

### Description:

Refactored `NameParser.php` by removing the unnecessary `$input` variable. The original code first assigned the lowercased value of `$input` to a new variable and then returned it. This step added an unnecessary line of code, since the result of `strtolower()` can be returned directly without storing it in a separate variable. This simplifies the code, making it more concise and easier to read, without altering its behavior.
