### PR TITLE
Add Command Option to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,4 +60,15 @@ You can also specify the path to the configuration file using the `--config` opt
 
 ---
 
+## Command Options
+
+The behaviour of `peck` can be modified with the following options:
+
+### `--config`
+
+By default `peck` will check for a `peck.json` file in your project root. If one isn't available it will try to figure
+out the directory to check by itself.
+
+---
+
 Peck is an open-sourced software licensed under the **[MIT license](https://opensource.org/licenses/MIT)**.


### PR DESCRIPTION
### What:

- [x] Not quite a New Feature

### Description:
This adds a section to the README titled "Command Option" - see below.

![image](https://github.com/user-attachments/assets/2340148c-4fed-4b29-8912-d35a8066677a)
