### PR TITLE
Config require config

### DIFF
--- a/src/Console/Commands/CheckCommand.php
+++ b/src/Console/Commands/CheckCommand.php
@@ -10,6 +10,7 @@ use Peck\Kernel;
 use Peck\ValueObjects\Issue;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -69,7 +70,12 @@ final class CheckCommand extends Command
     protected function configure(): void
     {
         $this->setDescription('Checks for misspellings in the given directory.')
-            ->addOption('config', 'c', InputOption::VALUE_OPTIONAL, 'The configuration file to use.', 'peck.json');
+            ->addOption(
+                'config',
+                'c',
+                InputArgument::OPTIONAL | InputOption::VALUE_REQUIRED,
+                'The configuration file to use.', 'peck.json'
+            );
     }
 
     /**

--- a/src/Console/Commands/CheckCommand.php
+++ b/src/Console/Commands/CheckCommand.php
@@ -85,7 +85,7 @@ final class CheckCommand extends Command
      *
      * @throws InvalidOptionException
      */
-    private function getConfigFile(InputInterface $input): void
+    private function intializeConfigFromParameter(InputInterface $input): void
     {
         $configurationPath = $input->getOption('config');
 

--- a/src/Console/Commands/CheckCommand.php
+++ b/src/Console/Commands/CheckCommand.php
@@ -32,7 +32,7 @@ final class CheckCommand extends Command
      */
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        $this->getConfigFile($input);
+        $this->intializeConfigFromParameter($input);
 
         $kernel = Kernel::default();
 

--- a/src/Console/Commands/CheckCommand.php
+++ b/src/Console/Commands/CheckCommand.php
@@ -10,6 +10,7 @@ use Peck\Kernel;
 use Peck\ValueObjects\Issue;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Exception\InvalidOptionException;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -31,8 +32,7 @@ final class CheckCommand extends Command
      */
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        $configurationPath = $input->getOption('config');
-        Config::resolveConfigFilePathUsing(fn (): mixed => $configurationPath);
+        $this->getConfigFile($input);
 
         $kernel = Kernel::default();
 
@@ -76,6 +76,24 @@ final class CheckCommand extends Command
                 InputArgument::OPTIONAL | InputOption::VALUE_REQUIRED,
                 'The configuration file to use.', 'peck.json'
             );
+    }
+
+    /**
+     * If a user passes a config option to the command, attempt to load that file.
+     *
+     * If the file doesn't exist, throw an exception
+     *
+     * @throws InvalidOptionException
+     */
+    private function getConfigFile(InputInterface $input): void
+    {
+        $configurationPath = $input->getOption('config');
+
+        if (! is_string($configurationPath) || ! file_exists($configurationPath)) {
+            throw new InvalidOptionException('The config file you tried to load does not exist.');
+        }
+
+        Config::resolveConfigFilePathUsing(fn (): mixed => $configurationPath);
     }
 
     /**

--- a/tests/Unit/ConsoleTest/ConsoleOutputTest.php
+++ b/tests/Unit/ConsoleTest/ConsoleOutputTest.php
@@ -19,7 +19,7 @@ it('requires a config value when --config is passed', function (): void {
     ]);
 })->throws(InvalidOptionException::class);
 
-it('it throws an exception when an invalid --config is passed', function (): void {
+it('throws an exception when an invalid --config is passed', function (): void {
     // Find the application
     $application = new Application;
     $application->add(new CheckCommand);
@@ -31,7 +31,7 @@ it('it throws an exception when an invalid --config is passed', function (): voi
     ]);
 })->throws(InvalidOptionException::class);
 
-it('it works when a valid --config is passed', function (): void {
+it('works when a valid --config is passed', function (): void {
     // Arrange
 
     // I've chosen to create a small config file here, as opposed to creating files all over the place, & losing track.

--- a/tests/Unit/ConsoleTest/ConsoleOutputTest.php
+++ b/tests/Unit/ConsoleTest/ConsoleOutputTest.php
@@ -32,6 +32,9 @@ it('it throws an exception when an invalid --config is passed', function (): voi
 })->throws(InvalidOptionException::class);
 
 it('it works when a valid --config is passed', function (): void {
+    // Arrange
+
+    // I've chosen to create a small config file here, as opposed to creating files all over the place, & losing track.
     $tempConfig = 'peck2.json';
     touch($tempConfig);
     file_put_contents($tempConfig, <<<'JSON'
@@ -57,6 +60,8 @@ JSON
     unlink($tempConfig);
 
     // Assert
+    // The "namespace" word has been removed from the exclusions, so that should be picked up,
+    // but the "config" should still be ignored
     expect($output)
         ->toContain('Did you mean: name space, name-space, names pace, names-pace')
         ->not()->toContain('Did you mean: con fig, con-fig, Cong, confide');

--- a/tests/Unit/ConsoleTest/ConsoleOutputTest.php
+++ b/tests/Unit/ConsoleTest/ConsoleOutputTest.php
@@ -19,7 +19,7 @@ it('requires a config value when --config is passed', function (): void {
     ]);
 })->throws(InvalidOptionException::class);
 
-it('W throw an exception when an invalid --config is passed', function (): void {
+it('it throws an exception when an invalid --config is passed', function (): void {
     // Find the application
     $application = new Application;
     $application->add(new CheckCommand);
@@ -31,7 +31,7 @@ it('W throw an exception when an invalid --config is passed', function (): void 
     ]);
 })->throws(InvalidOptionException::class);
 
-it('It works when a valid --config is passed', function (): void {
+it('it works when a valid --config is passed', function (): void {
     $tempConfig = 'peck2.json';
     touch($tempConfig);
     file_put_contents($tempConfig, <<<'JSON'

--- a/tests/Unit/ConsoleTest/ConsoleOutputTest.php
+++ b/tests/Unit/ConsoleTest/ConsoleOutputTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+use Peck\Console\Commands\CheckCommand;
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Exception\InvalidOptionException;
+use Symfony\Component\Console\Tester\CommandTester;
+
+it('requires a config value when --config is passed', function (): void {
+    // Find the application
+    $application = new Application;
+    $application->add(new CheckCommand);
+    $command = $application->find('check');
+
+    // Execute the command, but don't pass a config file
+    (new CommandTester($command))->execute([
+        '--config' => null,
+    ]);
+})->throws(InvalidOptionException::class);
+
+it('W throw an exception when an invalid --config is passed', function (): void {
+    // Find the application
+    $application = new Application;
+    $application->add(new CheckCommand);
+    $command = $application->find('check');
+
+    // Execute the command, but don't pass a config file
+    (new CommandTester($command))->execute([
+        '--config' => 'i-dont-exist',
+    ]);
+})->throws(InvalidOptionException::class);
+
+it('It works when a valid --config is passed', function (): void {
+    $tempConfig = 'peck2.json';
+    touch($tempConfig);
+    file_put_contents($tempConfig, <<<'JSON'
+{
+    "ignore": {
+        "words": [
+            "config",
+            "aspell",
+            "args",
+            "doc",
+            "bool",
+            "php",
+            "api"
+        ],
+        "directories": []
+    }
+}
+JSON
+    );
+
+    // Act
+    $output = shell_exec('./bin/peck --config='.$tempConfig);
+    unlink($tempConfig);
+
+    // Assert
+    expect($output)
+        ->toContain('Did you mean: name space, name-space, names pace, names-pace')
+        ->not()->toContain('Did you mean: con fig, con-fig, Cong, confide');
+});


### PR DESCRIPTION
- [x] Coding improvement
- [x]  Tests

## Changes

I've updated the --config option to:
```php
$this->setDescription('Checks for misspellings in the given directory.')
    ->addOption(
        'config',
        'c',
        InputArgument::OPTIONAL | InputOption::VALUE_REQUIRED,
        'The configuration file to use.', 'peck.json'
    );
```
This means that the `--config` option itself is optional, but if it is provided, a value is also required.

## Tests

I have supplied tests for all 3 scenarios:
1. `--config` is passed without a value -> An exception is thrown
2.  `--config` is passed with a config file that doesn't exist -> An exception is thrown
3.  `--config` is passed with a config file that exists

## Problems

Although the `composer test` suite is passing, the code is not contributing to the code coverage. I assume that in the case of the exceptions (cases 1 & 2), the code is being handled by Symfony's CommandTester. And in the case where a valid config file is passed, it is handled by `shell_exec`.

### Valid case problem.

Symfony's `CommandTester` has its own tests that can be run, but I'm not sure how that plays out with Pecks plans.