### PR TITLE
feature: initial symfony cache implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,5 +8,6 @@
 /composer.lock
 /phpunit.xml
 /vendor/
+/var/
 *.swp
 *.swo

--- a/.gitignore
+++ b/.gitignore
@@ -3,11 +3,11 @@
 /.vscode
 /.phpunit.result.cache
 /.phpunit.cache
+/.peck.cache
 /.php-cs-fixer.cache
 /.php-cs-fixer.php
 /composer.lock
 /phpunit.xml
 /vendor/
-/var/
 *.swp
 *.swo

--- a/bin/peck
+++ b/bin/peck
@@ -3,6 +3,7 @@
 
 declare(strict_types=1);
 
+use Peck\Console\Commands\Cache\ClearCommand;
 use Peck\Console\Commands\CheckCommand;
 use Symfony\Component\Console\Application;
 
@@ -22,9 +23,10 @@ $application = new Application(
     '0.0.1',
 );
 
-$application->add(
-    new CheckCommand(),
-);
+$application->addCommands([
+    new CheckCommand,
+    new ClearCommand
+]);
 
 $application->setDefaultCommand('check');
 

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,11 @@
 {
     "name": "peckphp/peck",
     "description": "Peck is a CLI tool that detects wording / or spelling mistakes in your codebase.",
-    "keywords": ["php", "spelling", "checker"],
+    "keywords": [
+        "php",
+        "spelling",
+        "checker"
+    ],
     "license": "MIT",
     "authors": [
         {
@@ -12,6 +16,7 @@
     "require": {
         "php": "^8.3.0",
         "nunomaduro/termwind": "^2.3",
+        "symfony/cache": "^7.2.1",
         "symfony/console": "^7.2.1",
         "symfony/finder": "^7.2.2",
         "tigitz/php-spellchecker": "^0.7.0"

--- a/src/Cache/CacheManager.php
+++ b/src/Cache/CacheManager.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Peck\Cache;
+
+use Symfony\Component\Cache\Adapter\FilesystemAdapter;
+use Symfony\Contracts\Cache\ItemInterface;
+
+/**
+ * @internal
+ */
+final readonly class CacheManager
+{
+    /**
+     * Creates a new instance of CacheManager.
+     */
+    public function __construct(private FilesystemAdapter $cache)
+    {
+        //
+    }
+
+    /**
+     * Creates the default instance of CacheManager.
+     */
+    public static function create(string $namespace = 'Peck', int $defaultLifetime = 3600): self
+    {
+        return new self(new FilesystemAdapter($namespace, $defaultLifetime, __DIR__.'/../../var/cache'));
+    }
+
+    /**
+     * Get the value of the given key from the cache.
+     */
+    public function get(string $key, ?callable $callback = null): mixed
+    {
+        return $this->cache->get($key, fn (ItemInterface $item) => $callback ? $callback($item) : null);
+    }
+
+    /**
+     * Set the value of the given key in the cache.
+     */
+    public function set(string $key, mixed $value, ?int $lifetime = null): void
+    {
+        $item = $this->cache->getItem($key);
+        $item->set($value);
+
+        if ($lifetime !== null) {
+            $item->expiresAfter($lifetime);
+        }
+
+        $this->cache->save($item);
+    }
+
+    /**
+     * Delete the value of the given key from the cache.
+     */
+    public function delete(string $key): void
+    {
+        $this->cache->deleteItem($key);
+    }
+
+    /**
+     * Clear the cache.
+     */
+    public function clear(string $prefix = ''): void
+    {
+        $this->cache->clear($prefix);
+    }
+}

--- a/src/Cache/CacheManager.php
+++ b/src/Cache/CacheManager.php
@@ -23,9 +23,9 @@ final readonly class CacheManager
     /**
      * Creates the default instance of CacheManager.
      */
-    public static function create(string $namespace = 'Peck', int $defaultLifetime = 3600): self
+    public static function create(string $namespace = 'Peck', int $defaultLifetime = 3600, ?string $cacheDirectory = null): self
     {
-        return new self(new FilesystemAdapter($namespace, $defaultLifetime, __DIR__.'/../../var/cache'));
+        return new self(new FilesystemAdapter($namespace, $defaultLifetime, $cacheDirectory ?? dirname(__DIR__, 5).'/.peck.cache'));
     }
 
     /**

--- a/src/Console/Commands/Cache/ClearCommand.php
+++ b/src/Console/Commands/Cache/ClearCommand.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Peck\Console\Commands\Cache;
+
+use Exception;
+use Symfony\Component\Cache\Adapter\FilesystemAdapter;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * @codeCoverageIgnore
+ *
+ * @internal
+ */
+#[AsCommand(
+    name: 'cache:clear',
+    description: 'Clears cached data.'
+)]
+final class ClearCommand extends Command
+{
+    /**
+     * Configures the command.
+     */
+    protected function configure(): void
+    {
+        $this->addArgument('namespace', InputArgument::OPTIONAL, 'Cache namespace to clear.', '');
+    }
+
+    /**
+     * Executes the command.
+     */
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $output->writeln('<info>Clearing cache...</info>');
+
+        $namespace = $input->getArgument('namespace');
+
+        try {
+            (new FilesystemAdapter(is_string($namespace) ? $namespace : ''))->clear();
+            $output->writeln('<info>Cache successfully cleared!</info>');
+
+            return Command::SUCCESS;
+        } catch (Exception $e) {
+            $output->writeln('<error>Failed to clear cache: '.$e->getMessage().'</error>');
+
+            return Command::FAILURE;
+        }
+    }
+}

--- a/src/Console/Commands/Cache/ClearCommand.php
+++ b/src/Console/Commands/Cache/ClearCommand.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Peck\Console\Commands\Cache;
 
 use Exception;
-use Symfony\Component\Cache\Adapter\FilesystemAdapter;
+use Peck\Cache\CacheManager;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
@@ -41,7 +41,11 @@ final class ClearCommand extends Command
         $namespace = $input->getArgument('namespace');
 
         try {
-            (new FilesystemAdapter(is_string($namespace) ? $namespace : ''))->clear();
+            CacheManager::create(
+                namespace: is_string($namespace) ? $namespace : '',
+                cacheDirectory: dirname(__DIR__, 7).'/.peck.cache'
+            )->clear();
+
             $output->writeln('<info>Cache successfully cleared!</info>');
 
             return Command::SUCCESS;

--- a/tests/Unit/Cache/CacheManagerTest.php
+++ b/tests/Unit/Cache/CacheManagerTest.php
@@ -5,10 +5,14 @@ declare(strict_types=1);
 use Peck\Cache\CacheManager;
 
 beforeEach(function (): void {
-    $this->cacheManager = CacheManager::create('Peck.CacheManagerTest', 3600, __DIR__.'/../../../.peck.cache');
+    $this->cacheManager = CacheManager::create(
+        namespace: 'Peck.CacheManagerTest',
+        cacheDirectory: __DIR__.'/../../../.peck.cache'
+    );
+    $this->cacheManager->clear();
 });
 
-afterAll(function (): void {
+afterEach(function (): void {
     $this->cacheManager->clear();
 });
 

--- a/tests/Unit/Cache/CacheManagerTest.php
+++ b/tests/Unit/Cache/CacheManagerTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 use Peck\Cache\CacheManager;
 
 beforeEach(function (): void {
-    $this->cacheManager = CacheManager::create('Peck.CacheManagerTest');
+    $this->cacheManager = CacheManager::create('Peck.CacheManagerTest', 3600, __DIR__.'/../../../.peck.cache');
 });
 
 afterAll(function (): void {

--- a/tests/Unit/Cache/CacheManagerTest.php
+++ b/tests/Unit/Cache/CacheManagerTest.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+use Peck\Cache\CacheManager;
+
+beforeEach(function (): void {
+    $this->cacheManager = CacheManager::create('Peck.CacheManagerTest');
+});
+
+afterAll(function (): void {
+    $this->cacheManager->clear();
+});
+
+it('can set and retrieve cached data', function (): void {
+    $key = 'test_key';
+    $value = ['data' => 'test_value'];
+
+    // Set the cache
+    $this->cacheManager->set($key, $value);
+
+    // Retrieve the cache
+    $cachedValue = $this->cacheManager->get($key);
+
+    expect($cachedValue)->toBe($value);
+});
+
+it('returns null for a non-existent cache key', function (): void {
+    $cachedValue = $this->cacheManager->get('non_existent_key');
+
+    expect($cachedValue)->toBeNull();
+});
+
+it('can delete a cached item', function (): void {
+    $key = 'delete_key';
+    $value = 'value_to_delete';
+
+    // Set the cache
+    $this->cacheManager->set($key, $value);
+
+    // Delete the cache
+    $this->cacheManager->delete($key);
+
+    // Retrieve the cache
+    $cachedValue = $this->cacheManager->get($key);
+
+    expect($cachedValue)->toBeNull();
+});
+
+it('can clear all cached items', function (): void {
+    $this->cacheManager->set('key1', 'value1');
+    $this->cacheManager->set('key2', 'value2');
+
+    // Clear the cache
+    $this->cacheManager->clear();
+
+    // Check if the cache is empty
+    $cachedValue1 = $this->cacheManager->get('key1');
+    $cachedValue2 = $this->cacheManager->get('key2');
+
+    expect($cachedValue1)->toBeNull();
+    expect($cachedValue2)->toBeNull();
+});
+
+it('can handle cache expiration', function (): void {
+    $key = 'expiring_key';
+    $value = 'expiring_value';
+
+    // Set the cache with a short lifetime
+    $this->cacheManager->set($key, $value, 1);
+
+    // Wait for the cache to expire
+    sleep(2);
+
+    // Retrieve the cache
+    $cachedValue = $this->cacheManager->get($key);
+
+    expect($cachedValue)->toBeNull();
+});

--- a/tests/Unit/Checkers/ClassCheckerTest.php
+++ b/tests/Unit/Checkers/ClassCheckerTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use Peck\Cache\CacheManager;
 use Peck\Checkers\ClassChecker;
 use Peck\Config;
 use Peck\Services\Spellcheckers\InMemorySpellchecker;
@@ -117,6 +118,7 @@ it('detects issues in the given directory, but ignores the whitelisted words', f
         new InMemorySpellchecker(
             $config,
             Aspell::create(),
+            CacheManager::create('Peck.ClassCheckerTest'),
         ),
     );
 

--- a/tests/Unit/Checkers/FileSystemCheckerTest.php
+++ b/tests/Unit/Checkers/FileSystemCheckerTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use Peck\Cache\CacheManager;
 use Peck\Checkers\FileSystemChecker;
 use Peck\Config;
 use Peck\Services\Spellcheckers\InMemorySpellchecker;
@@ -76,6 +77,7 @@ it('detects issues in the given directory, but ignores the whitelisted words', f
         new InMemorySpellchecker(
             $config,
             Aspell::create(),
+            CacheManager::create('Peck.FileSystemCheckerTest'),
         ),
     );
 

--- a/tests/Unit/Services/InMemorySpellcheckerTest.php
+++ b/tests/Unit/Services/InMemorySpellcheckerTest.php
@@ -2,7 +2,10 @@
 
 declare(strict_types=1);
 
+use Peck\Cache\CacheManager;
+use Peck\Config;
 use Peck\Services\Spellcheckers\InMemorySpellchecker;
+use PhpSpellcheck\Spellchecker\Aspell;
 
 it('does not detect issues', function (): void {
     $spellchecker = InMemorySpellchecker::default();
@@ -14,6 +17,28 @@ it('does not detect issues', function (): void {
 
 it('detects issues', function (): void {
     $spellchecker = InMemorySpellchecker::default();
+
+    $issues = $spellchecker->check('Hello viewerss');
+
+    expect($issues)->toHaveCount(1)
+        ->and($issues[0]->word)->toBe('viewerss')
+        ->and($issues[0]->suggestions)->toBe([
+            'viewers',
+            'viewer\'s',
+            'viewer',
+            'viewed',
+        ]);
+});
+
+it('caches the issues', function (): void {
+    $spellchecker = new InMemorySpellchecker(
+        Config::instance(),
+        Aspell::create(),
+        CacheManager::create(
+            namespace: 'Peck.CacheManagerTest',
+            cacheDirectory: __DIR__.'/../../../.peck.cache'
+        )
+    );
 
     $issues = $spellchecker->check('Hello viewerss');
 


### PR DESCRIPTION
### What:

- [ ] Bug Fix
- [x] New Feature

> [!NOTE]  
> Initial implementation uses file system caching only but can be expanded to use other adaptors as per https://symfony.com/doc/current/components/cache.html#available-cache-adapters 
>
> By default, cache is stored at project root level.

### Description:

This pull request introduces a caching system to improve the performance of the Peck package by utilising Symfony's Cache component. The caching system is integrated with a CacheManager class, which provides an abstraction for setting, retrieving, and clearing cached data. Additionally, a new cache flush command has been implemented for easy cache management.

### Related:

https://github.com/peckphp/peck/issues/22

### Command:

```bash
# clear cache by namespace
./vendor/bin/peck cache:clear Peck.InMemorySpellChecker
```

### Key Changes:

#### Caching Implementation

- Added a CacheManager class to handle caching operations using Symfony's FilesystemAdapter.
- Supports configurable cache directory and default lifetime for cached items.
- Provides methods for:
  - set(key, value, lifetime): Store cache data.
  - get(key, callback): Retrieve cache data or generate it if not present.
  - delete(key): Remove specific cache items.
  - clear(): Clear all cached data.

#### Cache Flush Command

- Introduced a cache:flush CLI command using Symfony Console.
- Command clears all cached data and provides feedback on success or failure.
- Added error handling to ensure robustness during cache flush operations.

#### Integration

- Integrated CacheManager into the main application to cache results for operations that may be repeated frequently.
- Added default cache directory (var/cache/) with flexibility for customisation.

#### Tests

- Added test suite using Pest to validate:
  - Setting and retrieving cached data.
  - Cache expiration behaviour.
  - Deleting and clearing cache items.


> [!NOTE]  
> Caching implementation has been integrated into the `InMemorySpellchecker::check()` method only, and can be easily integrated with other classes within its own caching directory/namespace