### PR TITLE
refactor: minor change to reduce memory overhead for larger datasets

### DIFF
--- a/src/Checkers/ClassChecker.php
+++ b/src/Checkers/ClassChecker.php
@@ -75,10 +75,11 @@ final readonly class ClassChecker implements Checker
 
         $reflectionClass = new ReflectionClass($class);
 
-        $namesToCheck = $this->getMethodNames($reflectionClass);
-
-        array_push($namesToCheck, ...$this->getPropertyNames($reflectionClass));
-        array_push($namesToCheck, ...$this->getConstantNames($reflectionClass));
+        $namesToCheck = array_merge(
+            $this->getMethodNames($reflectionClass),
+            $this->getPropertyNames($reflectionClass),
+            $this->getConstantNames($reflectionClass)
+        );
 
         if ($docComment = $reflectionClass->getDocComment()) {
             array_push($namesToCheck, ...explode(PHP_EOL, $docComment));

--- a/src/Checkers/ClassChecker.php
+++ b/src/Checkers/ClassChecker.php
@@ -75,14 +75,13 @@ final readonly class ClassChecker implements Checker
 
         $reflectionClass = new ReflectionClass($class);
 
-        $namesToCheck = array_merge(
-            $this->getMethodNames($reflectionClass),
-            $this->getPropertyNames($reflectionClass),
-            $this->getConstantNames($reflectionClass)
-        );
+        $namesToCheck = $this->getMethodNames($reflectionClass);
+
+        array_push($namesToCheck, ...$this->getPropertyNames($reflectionClass));
+        array_push($namesToCheck, ...$this->getConstantNames($reflectionClass));
 
         if ($docComment = $reflectionClass->getDocComment()) {
-            $namesToCheck = array_merge($namesToCheck, explode(PHP_EOL, $docComment));
+            array_push($namesToCheck, ...explode(PHP_EOL, $docComment));
         }
 
         if ($namesToCheck === []) {

--- a/src/Checkers/ClassChecker.php
+++ b/src/Checkers/ClassChecker.php
@@ -9,6 +9,7 @@ use Peck\Contracts\Checker;
 use Peck\Contracts\Services\Spellchecker;
 use Peck\Support\NameParser;
 use Peck\ValueObjects\Issue;
+use Peck\ValueObjects\Misspelling;
 use ReflectionClass;
 use ReflectionMethod;
 use ReflectionParameter;
@@ -92,15 +93,13 @@ final readonly class ClassChecker implements Checker
         $issues = [];
 
         foreach ($namesToCheck as $name) {
-            $misspellings = $this->spellchecker->check(NameParser::parse($name));
-
-            foreach ($misspellings as $misspelling) {
-                $issues[] = new Issue(
+            array_push($issues, ...array_map(
+                fn (Misspelling $misspelling): Issue => new Issue(
                     $misspelling,
                     $file->getRealPath(),
-                    $this->getErrorLine($file, $name)
-                );
-            }
+                    $this->getErrorLine($file, $name),
+                ), $this->spellchecker->check(NameParser::parse($name))
+            ));
         }
 
         return $issues;

--- a/src/Checkers/ClassChecker.php
+++ b/src/Checkers/ClassChecker.php
@@ -40,7 +40,7 @@ final readonly class ClassChecker implements Checker
      */
     public function check(array $parameters): array
     {
-        $classesFiles = Finder::create()
+        $finder = Finder::create()
             ->files()
             ->notPath($this->config->whitelistedDirectories)
             ->ignoreDotFiles(true)
@@ -48,21 +48,17 @@ final readonly class ClassChecker implements Checker
             ->ignoreUnreadableDirs()
             ->ignoreVCSIgnored(true)
             ->in($parameters['directory'])
-            ->name('*.php')
-            ->getIterator();
+            ->name('*.php');
 
         $issues = [];
 
-        foreach ($classesFiles as $classFile) {
-            $issues = [
-                ...$issues,
-                ...$this->getIssuesFromClass($classFile),
-            ];
+        foreach ($finder as $classFile) {
+            array_push($issues, ...$this->getIssuesFromClass($classFile));
         }
 
         usort($issues, fn (Issue $a, Issue $b): int => $a->file <=> $b->file);
 
-        return array_values($issues);
+        return $issues;
     }
 
     /**

--- a/src/Checkers/FileSystemChecker.php
+++ b/src/Checkers/FileSystemChecker.php
@@ -45,17 +45,13 @@ final readonly class FileSystemChecker implements Checker
         foreach ($finder as $fileOrDirectory) {
             $name = NameParser::parse($fileOrDirectory->getFilenameWithoutExtension());
 
-            array_push(
-                $issues,
-                ...array_map(
-                    fn (Misspelling $misspelling): Issue => new Issue(
-                        $misspelling,
-                        $fileOrDirectory->getRealPath(),
-                        0
-                    ),
-                    $this->spellchecker->check($name)
-                )
-            );
+            array_push($issues, ...array_map(
+                fn (Misspelling $misspelling): Issue => new Issue(
+                    $misspelling,
+                    $fileOrDirectory->getRealPath(),
+                    0
+                ), $this->spellchecker->check($name)
+            ));
         }
 
         usort($issues, fn (Issue $a, Issue $b): int => $a->file <=> $b->file);

--- a/src/Kernel.php
+++ b/src/Kernel.php
@@ -48,10 +48,7 @@ final readonly class Kernel
         $issues = [];
 
         foreach ($this->checkers as $checker) {
-            $issues = [
-                ...$issues,
-                ...$checker->check($parameters),
-            ];
+            array_push($issues, ...$checker->check($parameters));
         }
 
         return $issues;


### PR DESCRIPTION
### What:

- [ ] Bug Fix
- [ ] New Feature

### Description:

Some minor improvements reducing memory overhead:

`ClassChecker::check() & FileSystemChecker::check()`
- Replaced the spread operator with array_push() and unpacking (...) to prevent unnecessary intermediate arrays.
- Iterated directly over the Finder without calling getIterator(), as Finder is iterable.
- Kept the transformation of misspellings to issues concise, avoiding extra intermediate arrays.
- Removed array_values() as the array should be correctly sorted with sequential keys after usort().

`ClassChecker::getIssuesFromClass()`
- Replaced spread operator (...) with array_push() to avoid creating intermediate arrays.
- Added an early check for empty namesToCheck to skip unnecessary processing.

### Related:

https://github.com/peckphp/peck/issues/22
