### PR TITLE
[Suggestions] Filter the suggestions to not show words with apostrophes

### DIFF
--- a/src/Services/Spellcheckers/InMemorySpellchecker.php
+++ b/src/Services/Spellcheckers/InMemorySpellchecker.php
@@ -44,8 +44,23 @@ final readonly class InMemorySpellchecker implements Spellchecker
 
         return array_map(fn (MisspellingInterface $misspelling): Misspelling => new Misspelling(
             $misspelling->getWord(),
-            array_slice($misspelling->getSuggestions(), 0, 4),
+            $this->extractSuggestions($misspelling, count: 4),
         ), $misspellings);
+    }
+
+    /**
+     * Extracts the suggestions from the given misspelling.
+     * Filters words that can't be used in code (e.g. apostrophes).
+     *
+     * @return array<int, string>
+     */
+    private function extractSuggestions(MisspellingInterface $misspelling, int $count): array
+    {
+        $filteredSuggestions = array_filter($misspelling->getSuggestions(),
+            fn (string $suggestion): bool => in_array(preg_match('/[^a-zA-Z]/', $suggestion), [0, false], true)
+        );
+
+        return array_slice(array_values($filteredSuggestions), 0, $count);
     }
 
     /**

--- a/src/Services/Spellcheckers/InMemorySpellchecker.php
+++ b/src/Services/Spellcheckers/InMemorySpellchecker.php
@@ -80,6 +80,9 @@ final readonly class InMemorySpellchecker implements Spellchecker
             fn (string $suggestion): bool => in_array(preg_match('/[^a-zA-Z]/', $suggestion), [0, false], true)
         );
 
+        // Remove duplicate identical suggestions
+        $filteredSuggestions = array_unique($filteredSuggestions);
+
         return array_slice(array_values($filteredSuggestions), 0, $count);
     }
 


### PR DESCRIPTION
### What:

- [X] Bug Fix
- [ ] New Feature

### Description:

When coding we don't want to have suggestions like `checker's` but only `checkers`.
I did not add test, as I want to wait for some more pull requests to get merged, before I get a lot of conflicts.

**Before and After:**

<img width="873" alt="Bildschirmfoto 2025-01-06 um 23 16 13" src="https://github.com/user-attachments/assets/8ab78379-de53-4741-a7fa-d41d64e33d7e" />

### Related:


