### PR TITLE
fix: getIssueColumn for files and folders

### DIFF
--- a/src/Console/Commands/CheckCommand.php
+++ b/src/Console/Commands/CheckCommand.php
@@ -212,7 +212,9 @@ final class CheckCommand extends Command
     private function getIssueColumn(Issue $issue, string $lineContent): int
     {
         $fromColumn = isset($this->lastColumn[$issue->file][$issue->line][$issue->misspelling->word]) ? $this->lastColumn[$issue->file][$issue->line][$issue->misspelling->word] + 1 : 0;
-        $column = strpos(strtolower($lineContent), $issue->misspelling->word, $fromColumn);
+        $projectDirectory = (string) realpath(__DIR__.'/../../../');
+        $lineContent = str_replace(strtolower($projectDirectory), '', strtolower($lineContent));
+        $column = strpos($lineContent, $issue->misspelling->word, $fromColumn);
 
         if ($column === false) {
             throw (new Exception("Could not find the misspelling '{$issue->misspelling->word}' in the line '{$lineContent}'"));

--- a/tests/.pest/snapshots/Console/OutputTest/it_may_fail.snap
+++ b/tests/.pest/snapshots/Console/OutputTest/it_may_fail.snap
@@ -1,26 +1,26 @@
 
    ISSUE  Misspelling in [1m/./FolderWithTypoos[0m: '[1mtypoos[0m'  
   /tests/Fixtures/FolderWithTypoos     
-  ----------------------------------------------------------^     
-  Did you mean: Typos, Typo's, Types, Type's  
+  --------------------------^     
+  Did you mean: typos, typo's, types, type's  
 
 
    ISSUE  Misspelling in [1m/./FolderWithTypoos/FileThatShouldBeIgnroed.php[0m: '[1mignroed[0m'  
   /tests/Fixtures/FolderWithTypoos/FileThatShouldBeIgnroed.php     
-  ---------------------------------------------------------------------------------^     
-  Did you mean: Ignored, Ignores, Ignore, Inroad  
+  -------------------------------------------------^     
+  Did you mean: ignored, ignores, ignore, inroad  
 
 
    ISSUE  Misspelling in [1m/./FolderWithTypoos/FileWithTppyo.php[0m: '[1mtppyo[0m'  
   /tests/Fixtures/FolderWithTypoos/FileWithTppyo.php     
-  -------------------------------------------------------------------------^     
-  Did you mean: Typo, Tokyo, Typos, Topi  
+  -----------------------------------------^     
+  Did you mean: typo, Tokyo, typos, topi  
 
 
    ISSUE  Misspelling in [1m/./FolderWithTypoos/FolderThatShouldBeIgnored/FileThatShoudBeIgnoredBecauseItsInsideWhitelistedFolder.php[0m: '[1mshoud[0m'  
   /tests/Fixtures/FolderWithTypoos/FolderThatShouldBeIgnored/FileThatShoudBeIgnoredBecauseItsInsideWhitelistedFolder.php     
-  ---------------------------------------------------------------------------------------------------^     
-  Did you mean: Should, Shroud, Shod, Shout  
+  -------------------------------------------------------------------^     
+  Did you mean: should, shroud, shod, shout  
 
 
    ISSUE  Misspelling in [1m/./ClassesToTest/ClassWithTypoErrors.php:30:34[0m: '[1merorr[0m'  


### PR DESCRIPTION
<!--
- Fill in the form below correctly. This will help the Peck team to understand the PR and also work on it.
-->

### What:

- [x] Bug Fix
- [ ] New Feature

### Description:

This PR fixes an issue with retrieving the correct column number for displaying the location of typos in file and folder names. This issue was making the snapshot tests to fail on different machines.

### Related:

https://github.com/peckphp/peck/pull/28
