### PR TITLE
refactor: remove redundant code / unnecessary variable assignments

### DIFF
--- a/src/Checkers/ClassChecker.php
+++ b/src/Checkers/ClassChecker.php
@@ -62,7 +62,7 @@ final readonly class ClassChecker implements Checker
 
         usort($issues, fn (Issue $a, Issue $b): int => $a->file <=> $b->file);
 
-        return array_values($issues);
+        return $issues;
     }
 
     /**

--- a/src/Checkers/FileSystemChecker.php
+++ b/src/Checkers/FileSystemChecker.php
@@ -44,8 +44,7 @@ final readonly class FileSystemChecker implements Checker
         $issues = [];
 
         foreach ($filesOrDirectories as $fileOrDirectory) {
-            $name = $fileOrDirectory->getFilenameWithoutExtension();
-            $name = NameParser::parse($name);
+            $name = NameParser::parse($fileOrDirectory->getFilenameWithoutExtension());
 
             $issues = [
                 ...$issues,
@@ -60,6 +59,6 @@ final readonly class FileSystemChecker implements Checker
 
         usort($issues, fn (Issue $a, Issue $b): int => $a->file <=> $b->file);
 
-        return array_values($issues);
+        return $issues;
     }
 }

--- a/src/Support/NameParser.php
+++ b/src/Support/NameParser.php
@@ -12,18 +12,12 @@ final readonly class NameParser
      */
     public static function parse(string $input): string
     {
-        // Trim leading underscores (e.g. __construct -> construct)
-        $input = ltrim($input, '_');
-
-        // Replace underscores and hyphens with spaces (for snake, screaming snake, and kebab case)
-        $input = str_replace(['_', '-'], ' ', $input);
-
-        // Add spaces before capital letters (for camel and pascal case)
-        $input = (string) preg_replace('/([a-z])([A-Z])/', '$1 $2', $input);
-
-        // Lowercase the input
-        $input = strtolower($input);
-
-        return $input;
+        return strtolower(
+            (string) preg_replace(
+                '/([a-z])([A-Z])/',
+                '$1 $2',
+                str_replace(['_', '-'], ' ', ltrim($input, '_'))
+            )
+        );
     }
 }

--- a/src/Support/NameParser.php
+++ b/src/Support/NameParser.php
@@ -12,13 +12,16 @@ final readonly class NameParser
      */
     public static function parse(string $input): string
     {
-        $trimmed = ltrim($input, '_');
+        // Remove leading underscores
+        $input = ltrim($input, '_');
 
-        $dashed = str_replace(['_', '-'], ' ', $trimmed);
+        // Replace underscores and dashes with spaces
+        $input = str_replace(['_', '-'], ' ', $input);
 
-        // Add spaces before capital letters (for camel and pascal case)
-        $words = (string) preg_replace('/([a-z])([A-Z])/', '$1 $2', $dashed);
+        // Insert spaces between lowercase and uppercase letters (camelCase or PascalCase)
+        $input = (string) preg_replace('/([a-z])([A-Z])/', '$1 $2', $input);
 
-        return strtolower($words);
+        // Convert the final result to lowercase
+        return strtolower($input);
     }
 }

--- a/src/Support/NameParser.php
+++ b/src/Support/NameParser.php
@@ -12,12 +12,13 @@ final readonly class NameParser
      */
     public static function parse(string $input): string
     {
-        return strtolower(
-            (string) preg_replace(
-                '/([a-z])([A-Z])/',
-                '$1 $2',
-                str_replace(['_', '-'], ' ', ltrim($input, '_'))
-            )
-        );
+        $trimmed = ltrim($input, '_');
+
+        $dashed = str_replace(['_', '-'], ' ', $trimmed);
+
+        // Add spaces before capital letters (for camel and pascal case)
+        $words = (string) preg_replace('/([a-z])([A-Z])/', '$1 $2', $dashed);
+
+        return strtolower($words);
     }
 }


### PR DESCRIPTION
### What:

- [ ] Bug Fix
- [ ] New Feature

### Description:

Redo of https://github.com/peckphp/peck/pull/53 with only the redundant code parts.

- removed `array_values` at the end of return; is redundant unless `usort` introduces gaps in the array keys, which I don't believe it does. In which case we can directly return $issues after sorting
- extra assignment of `$name` combined into a single line
- updated NameParser::parse to return with `strtolower` to remove unnecessary assignments (without affecting readability)