### PR TITLE
docs: add --dev flag to composer install

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Leveraging the robust capabilities of **[GNU Aspell](https://en.wikipedia.org/wi
 You can require Peck using [Composer](https://getcomposer.org) with the following command:
 
 ```bash
-composer require peckphp/peck
+composer require peckphp/peck --dev
 ```
 
 ## Usage


### PR DESCRIPTION
### What:

- [ ] Bug Fix
- [ ] New Feature
- [x] Documentation

### Description:

Make Composer Install Instructions Clearer by including the `--dev` flag in the composer install command.