### PR TITLE
[Scanner]: Introduce a Scanner class to handle file logic before checkers

### DIFF
--- a/src/Checkers/FileSystemChecker.php
+++ b/src/Checkers/FileSystemChecker.php
@@ -4,13 +4,12 @@ declare(strict_types=1);
 
 namespace Peck\Checkers;
 
-use Peck\Config;
 use Peck\Contracts\Checker;
 use Peck\Contracts\Services\Spellchecker;
 use Peck\Support\NameParser;
 use Peck\ValueObjects\Issue;
 use Peck\ValueObjects\Misspelling;
-use Symfony\Component\Finder\Finder;
+use Symfony\Component\Finder\SplFileInfo;
 
 /**
  * @internal
@@ -21,45 +20,41 @@ final readonly class FileSystemChecker implements Checker
      * Creates a new instance of FileSystemChecker.
      */
     public function __construct(
-        private Config $config,
         private Spellchecker $spellchecker,
     ) {}
 
     /**
-     * Checks for issues in the given directory.
+     * Checks the given file for issues.
      *
-     * @param  array<string, string>  $parameters
      * @return array<int, Issue>
      */
-    public function check(array $parameters): array
+    public function check(SplFileInfo $file): array
     {
-        $filesOrDirectories = Finder::create()
-            ->notPath($this->config->whitelistedDirectories)
-            ->ignoreDotFiles(true)
-            ->ignoreUnreadableDirs()
-            ->ignoreVCSIgnored(true)
-            ->in($parameters['directory'])
-            ->getIterator();
+        $name = NameParser::parse($file->getFilenameWithoutExtension());
 
-        $issues = [];
-
-        foreach ($filesOrDirectories as $fileOrDirectory) {
-            $name = $fileOrDirectory->getFilenameWithoutExtension();
-            $name = NameParser::parse($name);
-
-            $issues = [
-                ...$issues,
-                ...array_map(
-                    fn (Misspelling $misspelling): Issue => new Issue(
-                        $misspelling,
-                        $fileOrDirectory->getRealPath(),
-                        0,
-                    ), $this->spellchecker->check($name)),
-            ];
-        }
+        $issues = array_map(
+            fn (Misspelling $misspelling): Issue => new Issue(
+                $misspelling,
+                $file->getRealPath(),
+                0,
+            ),
+            $this->spellchecker->check($name)
+        );
 
         usort($issues, fn (Issue $a, Issue $b): int => $a->file <=> $b->file);
 
         return array_values($issues);
+    }
+
+    /**
+     * Checks if the checker supports the given file.
+     */
+    public function supports(SplFileInfo $file): bool
+    {
+        if ($file->isDir()) {
+            return true;
+        }
+
+        return $file->isFile() && $file->getExtension() === 'php';
     }
 }

--- a/src/Console/Commands/CheckCommand.php
+++ b/src/Console/Commands/CheckCommand.php
@@ -35,6 +35,7 @@ final class CheckCommand extends Command
      */
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
+
         renderUsing($output);
 
         $configurationPath = $input->getOption('config');
@@ -49,7 +50,8 @@ final class CheckCommand extends Command
         $output->writeln('');
 
         if ($issues === []) {
-            render(<<<'HTML'
+            render(
+                <<<'HTML'
                 <div class="mx-2 mb-1">
                     <div class="space-x-1">
                         <span class="bg-green text-white px-1 font-bold">PASS</span>
@@ -84,6 +86,12 @@ final class CheckCommand extends Command
                 'p',
                 InputArgument::OPTIONAL | InputOption::VALUE_REQUIRED,
                 'The path to check for misspellings.'
+            )
+            ->addOption(
+                'parallel',
+                'P',
+                InputOption::VALUE_NONE,
+                'Run the checks in parallel.'
             );
     }
 

--- a/src/Contracts/Checker.php
+++ b/src/Contracts/Checker.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Peck\Contracts;
 
 use Peck\ValueObjects\Issue;
+use Symfony\Component\Finder\SplFileInfo;
 
 /**
  * @internal
@@ -12,10 +13,15 @@ use Peck\ValueObjects\Issue;
 interface Checker
 {
     /**
-     * Checks of issues in the given text.
+     * Checks the given file for issues.
      *
-     * @param  array<string, string>  $parameters
      * @return array<int, Issue>
      */
-    public function check(array $parameters): array;
+    public function check(SplFileInfo $file): array;
+
+    /**
+     * Checks if the checker supports the given file.
+     * (Some checkers may only support certain file types, e.g. PHP files).
+     */
+    public function supports(SplFileInfo $file): bool;
 }

--- a/src/Kernel.php
+++ b/src/Kernel.php
@@ -4,19 +4,13 @@ declare(strict_types=1);
 
 namespace Peck;
 
-use Peck\Checkers\ClassChecker;
-use Peck\Checkers\FileSystemChecker;
-use Peck\Services\Spellcheckers\InMemorySpellchecker;
-
 final readonly class Kernel
 {
     /**
      * Creates a new instance of Kernel.
-     *
-     * @param  array<int, Contracts\Checker>  $checkers
      */
     public function __construct(
-        private array $checkers,
+        private Scanner $scanner
     ) {
         //
     }
@@ -26,34 +20,19 @@ final readonly class Kernel
      */
     public static function default(): self
     {
-        $config = Config::instance();
-        $inMemoryChecker = InMemorySpellchecker::default();
-
         return new self(
-            [
-                new FileSystemChecker($config, $inMemoryChecker),
-                new ClassChecker($config, $inMemoryChecker),
-            ],
+            Scanner::default()
         );
     }
 
     /**
      * Handles the given parameters.
      *
-     * @param  array{directory?: string}  $parameters
+     * @param  array{directory: string}  $parameters
      * @return array<int, ValueObjects\Issue>
      */
     public function handle(array $parameters): array
     {
-        $issues = [];
-
-        foreach ($this->checkers as $checker) {
-            $issues = [
-                ...$issues,
-                ...$checker->check($parameters),
-            ];
-        }
-
-        return $issues;
+        return $this->scanner->scan($parameters);
     }
 }

--- a/src/Scanner.php
+++ b/src/Scanner.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Peck;
+
+use Peck\Checkers\ClassChecker;
+use Peck\Checkers\FileSystemChecker;
+use Peck\Contracts\Checker;
+use Peck\Services\Spellcheckers\InMemorySpellchecker;
+use Peck\ValueObjects\Issue;
+use Symfony\Component\Finder\Finder;
+
+final readonly class Scanner
+{
+    /**
+     * @param  array<Checker>  $checkers
+     */
+    public function __construct(
+        private Config $config,
+        private array $checkers = []
+    ) {}
+
+    public static function default(): self
+    {
+        $inMemoryChecker = InMemorySpellchecker::default();
+
+        return new self(
+            Config::instance(),
+            [
+                new FileSystemChecker($inMemoryChecker),
+                new ClassChecker($inMemoryChecker),
+            ]
+        );
+    }
+
+    /**
+     * @param  array{directory: string}  $parameters
+     * @return array<int, Issue>
+     */
+    public function scan(array $parameters): array
+    {
+        $filesOrDirectories = Finder::create()
+            ->notPath($this->config->whitelistedDirectories)
+            ->ignoreDotFiles(true)
+            ->ignoreUnreadableDirs()
+            ->ignoreVCSIgnored(true)
+            ->in($parameters['directory'])
+            ->getIterator();
+
+        $issues = [];
+
+        foreach ($filesOrDirectories as $fileOrDirectory) {
+            foreach ($this->checkers as $checker) {
+
+                if (! $checker->supports($fileOrDirectory)) {
+                    $issues = [
+                        ...$issues,
+                        ...$checker->check($fileOrDirectory),
+                    ];
+                }
+            }
+        }
+
+        return $issues;
+    }
+}


### PR DESCRIPTION
### What:

- [ ] Bug Fix
- [ ] New Feature
- [X] Refactor

### Description:

> [!NOTE]  
> This is just a first draft! I am looking for active feedback on this, so we can develop this feature together. So before you open a new pull request with a slightly different version, feel free to write a review or suggestion here. I am more than open to accepting your suggestions on this topic!

This pull request adds a new Scanner class as introduced in #22 which handles the file scanning and then calls the checkers for each class. 

In #22 it was proposed to also create the reflection in the scanner, in order to only have to create one reflection, which we then can process in multiple classes. However, at the moment we have one checker that checks the file's path and name and one checker that uses reflection.

I already had to add a function `supports()` in the Checker Interface to know when to call which checker.

> [!IMPORTANT]  
> At the moment the tests obviously fail, as I changed the interfaces and checkers so the initialization and tests are all messed up. Before fixing the test suite I would love to get your feedback to further develop this feature


### Related:

- #22 
- #38