### PR TITLE
feat: show execution duration

### DIFF
--- a/src/Console/Commands/CheckCommand.php
+++ b/src/Console/Commands/CheckCommand.php
@@ -35,6 +35,7 @@ final class CheckCommand extends Command
      */
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
+        $start = microtime(true);
         renderUsing($output);
 
         $configurationPath = $input->getOption('config');
@@ -49,11 +50,14 @@ final class CheckCommand extends Command
         $output->writeln('');
 
         if ($issues === []) {
-            render(<<<'HTML'
+            render(<<<HTML
                 <div class="mx-2 mb-1">
-                    <div class="space-x-1">
+                    <div class="space-x-1 mb-1">
                         <span class="bg-green text-white px-1 font-bold">PASS</span>
                         <span>No misspellings found in your project.</span>
+                    </div>
+                    <div>
+                        <span class="font-bold text-gray-600">Duration:</span> {$this->getDuration($start)}s
                     </div>
                 </div>
                 HTML
@@ -68,6 +72,15 @@ final class CheckCommand extends Command
                 default => $this->renderLineLessIssue($issue, $directory),
             };
         }
+
+        render(<<<HTML
+            <div class="mx-2 mb-1">
+                <div>
+                    <span class="font-bold">Duration:</span> {$this->getDuration($start)}s
+                </div>
+            </div>
+            HTML
+        );
 
         return Command::FAILURE;
     }
@@ -219,5 +232,10 @@ final class CheckCommand extends Command
         }
 
         return $column;
+    }
+
+    private function getDuration(float $startTime): string
+    {
+        return number_format(microtime(true) - $startTime, 2);
     }
 }

--- a/tests/.pest/snapshots/Console/OutputTest/it_may_fail.snap
+++ b/tests/.pest/snapshots/Console/OutputTest/it_may_fail.snap
@@ -77,3 +77,5 @@
   Did you mean: property, propriety, properer, properest  
 
 
+  Duration: 0.00s
+  

--- a/tests/.pest/snapshots/Console/OutputTest/it_may_pass.snap
+++ b/tests/.pest/snapshots/Console/OutputTest/it_may_pass.snap
@@ -1,3 +1,4 @@
 
    PASS  No misspellings found in your project.  
 
+   Duration: 0.00s

--- a/tests/Console/OutputTest.php
+++ b/tests/Console/OutputTest.php
@@ -12,7 +12,14 @@ it('may fail', function (): void {
     $output = $process->getOutput();
 
     expect($exitCode)->toBe(1)
-        ->and($output)->toMatchSnapshot();
+        ->and($output)->pipe('toMatchSnapshot', function (Closure $next) use ($output) {
+            preg_match('/Duration: ([0-9.]+)s/', $output, $matches);
+            if (is_string($this->value)) {
+                $this->value = str_replace($matches[1], '0.00', $this->value);
+            }
+
+            return $next();
+        });
 });
 
 it('may pass', function (): void {
@@ -23,5 +30,12 @@ it('may pass', function (): void {
     $output = $process->getOutput();
 
     expect($exitCode)->toBe(0)
-        ->and($output)->toMatchSnapshot();
+        ->and($output)->pipe('toMatchSnapshot', function (Closure $next) use ($output) {
+            preg_match('/Duration: ([0-9.]+)s/', $output, $matches);
+            if (is_string($this->value)) {
+                $this->value = str_replace($matches[1], '0.00', $this->value);
+            }
+
+            return $next();
+        });
 });


### PR DESCRIPTION
### What:

- [X] New Feature

### Description:

This PR aims to add the execution duration of the peck

![CleanShot 2025-01-09 at 19 49 24@2x](https://github.com/user-attachments/assets/6ef47618-bf3d-4e82-997f-07de295c0f75)

