### PR TITLE
[Checker]: Add Support for Interfaces, Traits and Enums (ClassChecker -> SourceCodeChecker) (New #49)

### DIFF
--- a/peck.json
+++ b/peck.json
@@ -11,7 +11,9 @@
             "json",
             "php",
             "api",
-            "formatter"
+            "formatter",
+            "enum",
+            "enums"
         ],
         "directories": []
     }

--- a/peck.json
+++ b/peck.json
@@ -13,7 +13,8 @@
             "api",
             "formatter",
             "enum",
-            "enums"
+            "enums",
+            "backend"
         ],
         "directories": []
     }

--- a/src/Checkers/SourceCodeChecker.php
+++ b/src/Checkers/SourceCodeChecker.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Peck\Checkers;
 
+use BackedEnum;
 use Peck\Config;
 use Peck\Contracts\Checker;
 use Peck\Contracts\Services\Spellchecker;
@@ -153,6 +154,7 @@ final readonly class SourceCodeChecker implements Checker
 
     /**
      * Get the constant names and their values contained in the given reflection.
+     * This also includes cases from enums and their values (for string backed enums).
      *
      * @param  ReflectionClass<object>  $reflection
      * @return array<int, string>
@@ -163,7 +165,7 @@ final readonly class SourceCodeChecker implements Checker
 
         return array_values(array_filter([
             ...array_keys($constants),
-            ...array_values($constants),
+            ...array_map(fn (mixed $value): mixed => $value instanceof BackedEnum && is_string($value->value) ? $value->value : $value, array_values($constants)),
         ], fn (mixed $values): bool => is_string($values)));
     }
 

--- a/src/Kernel.php
+++ b/src/Kernel.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Peck;
 
-use Peck\Checkers\ClassChecker;
 use Peck\Checkers\FileSystemChecker;
+use Peck\Checkers\SourceCodeChecker;
 use Peck\Services\Spellcheckers\InMemorySpellchecker;
 
 final readonly class Kernel
@@ -32,7 +32,7 @@ final readonly class Kernel
         return new self(
             [
                 new FileSystemChecker($config, $inMemoryChecker),
-                new ClassChecker($config, $inMemoryChecker),
+                new SourceCodeChecker($config, $inMemoryChecker),
             ],
         );
     }

--- a/tests/.pest/snapshots/Console/OutputTest/it_may_fail.snap
+++ b/tests/.pest/snapshots/Console/OutputTest/it_may_fail.snap
@@ -77,3 +77,123 @@
   Did you mean: property, propriety, properer, properest  
 
 
+   ISSUE  Misspelling in [1m./tests/Fixtures/ClassesToTest/InterfaceWithSpellingMistake.php:12:34[0m: '[1merorr[0m'  
+    12▕ [1m    public function methodWithTypoErorr(): string;[0m  
+        ----------------------------------^     
+  Did you mean: error, errors, orr, err  
+
+
+   ISSUE  Misspelling in [1m./tests/Fixtures/ClassesToTest/InterfaceWithSpellingMistake.php:8:3[0m: '[1mspellling[0m'  
+     8▕ [1m * Spellling mistake in the interface documentation.[0m  
+        ---^     
+  Did you mean: spelling, spilling, spell ling, spell-ling  
+
+
+   ISSUE  Misspelling in [1m./tests/Fixtures/ClassesToTest/TraitWithTypo.php:25:31[0m: '[1mspellling[0m'  
+    25▕ [1m    private function methodWithSpelllingMistakeInName(): void[0m  
+        -------------------------------^     
+  Did you mean: spelling, spilling, spell ling, spell-ling  
+
+
+   ISSUE  Misspelling in [1m./tests/Fixtures/ClassesToTest/TraitWithTypo.php:30:67[0m: '[1mspellling[0m'  
+    30▕ [1m    private function methodWithSpellingMistakeInParameters(string $spelllingMistakeInParameter): void[0m  
+        -------------------------------------------------------------------^     
+  Did you mean: spelling, spilling, spell ling, spell-ling  
+
+
+   ISSUE  Misspelling in [1m./tests/Fixtures/ClassesToTest/TraitWithTypo.php:41:31[0m: '[1mspellling[0m'  
+    41▕ [1m     * This is a method with a spellling mistake in the doc block.[0m  
+        -------------------------------^     
+  Did you mean: spelling, spilling, spell ling, spell-ling  
+
+
+   ISSUE  Misspelling in [1m./tests/Fixtures/ClassesToTest/TraitWithTypo.php:18:16[0m: '[1mproperyt[0m'  
+    18▕ [1m    public int $properytWithSpelllingMistake = 2;[0m  
+        ----------------^     
+  Did you mean: property, propriety, properer, properest  
+
+
+   ISSUE  Misspelling in [1m./tests/Fixtures/ClassesToTest/TraitWithTypo.php:18:28[0m: '[1mspellling[0m'  
+    18▕ [1m    public int $properytWithSpelllingMistake = 2;[0m  
+        ----------------------------^     
+  Did you mean: spelling, spilling, spell ling, spell-ling  
+
+
+   ISSUE  Misspelling in [1m./tests/Fixtures/ClassesToTest/TraitWithTypo.php:10:25[0m: '[1mtst[0m'  
+    10▕ [1m * This trait is used to tst type errors in trait properties, methods, method parameters and trait documentation block.[0m  
+        -------------------------^     
+  Did you mean: test, tat, st, st  
+
+
+   ISSUE  Misspelling in [1m./tests/Fixtures/EnumsToTest/BackendEnumWithTypoErrors.php:21:31[0m: '[1mspellling[0m'  
+    21▕ [1m    private function methodWithSpelllingMistakeInName(): void[0m  
+        -------------------------------^     
+  Did you mean: spelling, spilling, spell ling, spell-ling  
+
+
+   ISSUE  Misspelling in [1m./tests/Fixtures/EnumsToTest/BackendEnumWithTypoErrors.php:26:67[0m: '[1mspellling[0m'  
+    26▕ [1m    private function methodWithSpellingMistakeInParameters(string $spelllingMistakeInParameter): void[0m  
+        -------------------------------------------------------------------^     
+  Did you mean: spelling, spilling, spell ling, spell-ling  
+
+
+   ISSUE  Misspelling in [1m./tests/Fixtures/EnumsToTest/BackendEnumWithTypoErrors.php:37:31[0m: '[1mspellling[0m'  
+    37▕ [1m     * This is a method with a spellling mistake in the doc block.[0m  
+        -------------------------------^     
+  Did you mean: spelling, spilling, spell ling, spell-ling  
+
+
+   ISSUE  Misspelling in [1m./tests/Fixtures/EnumsToTest/BackendEnumWithTypoErrors.php:13:9[0m: '[1mspellling[0m'  
+    13▕ [1m    case SPELLLING_MISTAKE_IN_CASE_NAME = 'Spelling mistake in case name';[0m  
+        ---------^     
+  Did you mean: spelling, spilling, spell ling, spell-ling  
+
+
+   ISSUE  Misspelling in [1m./tests/Fixtures/EnumsToTest/BackendEnumWithTypoErrors.php:14:43[0m: '[1mspellling[0m'  
+    14▕ [1m    case SPELLING_MISTAKE_IN_CASE_VALUE = 'Spellling mistake in case value';[0m  
+        -------------------------------------------^     
+  Did you mean: spelling, spilling, spell ling, spell-ling  
+
+
+   ISSUE  Misspelling in [1m./tests/Fixtures/EnumsToTest/BackendEnumWithTypoErrors.php:8:30[0m: '[1mspellling[0m'  
+     8▕ [1m * Even the documentation has spellling mistakes.[0m  
+        ------------------------------^     
+  Did you mean: spelling, spilling, spell ling, spell-ling  
+
+
+   ISSUE  Misspelling in [1m./tests/Fixtures/EnumsToTest/FolderThatShouldBeIgnored/EnumWithTypoErrors.php:9:19[0m: '[1mspellling[0m'  
+     9▕ [1m    case CASE_WITH_SPELLLING_MISTAKE_IN_CASE_NAME;[0m  
+        -------------------^     
+  Did you mean: spelling, spilling, spell ling, spell-ling  
+
+
+   ISSUE  Misspelling in [1m./tests/Fixtures/EnumsToTest/UnitEnumWithTypoErrors.php:20:31[0m: '[1mspellling[0m'  
+    20▕ [1m    private function methodWithSpelllingMistakeInName(): void[0m  
+        -------------------------------^     
+  Did you mean: spelling, spilling, spell ling, spell-ling  
+
+
+   ISSUE  Misspelling in [1m./tests/Fixtures/EnumsToTest/UnitEnumWithTypoErrors.php:25:67[0m: '[1mspellling[0m'  
+    25▕ [1m    private function methodWithSpellingMistakeInParameters(string $spelllingMistakeInParameter): void[0m  
+        -------------------------------------------------------------------^     
+  Did you mean: spelling, spilling, spell ling, spell-ling  
+
+
+   ISSUE  Misspelling in [1m./tests/Fixtures/EnumsToTest/UnitEnumWithTypoErrors.php:36:31[0m: '[1mspellling[0m'  
+    36▕ [1m     * This is a method with a spellling mistake in the doc block.[0m  
+        -------------------------------^     
+  Did you mean: spelling, spilling, spell ling, spell-ling  
+
+
+   ISSUE  Misspelling in [1m./tests/Fixtures/EnumsToTest/UnitEnumWithTypoErrors.php:13:19[0m: '[1mspellling[0m'  
+    13▕ [1m    case CASE_WITH_SPELLLING_MISTAKE_IN_CASE_NAME;[0m  
+        -------------------^     
+  Did you mean: spelling, spilling, spell ling, spell-ling  
+
+
+   ISSUE  Misspelling in [1m./tests/Fixtures/EnumsToTest/UnitEnumWithTypoErrors.php:8:30[0m: '[1mspellling[0m'  
+     8▕ [1m * Even the documentation has spellling mistakes.[0m  
+        ------------------------------^     
+  Did you mean: spelling, spilling, spell ling, spell-ling  
+
+

--- a/tests/Fixtures/ClassesToTest/ClassWithTypoErrors.php
+++ b/tests/Fixtures/ClassesToTest/ClassWithTypoErrors.php
@@ -11,7 +11,7 @@ namespace Tests\Fixtures\ClassesToTest;
  *
  * @internal
  */
-final class ClassWithTypoErrors
+final class ClassWithTypoErrors implements InterfaceWithSpellingMistake
 {
     public int $propertyWithoutTypoError = 1;
 

--- a/tests/Fixtures/ClassesToTest/InterfaceWithSpellingMistake.php
+++ b/tests/Fixtures/ClassesToTest/InterfaceWithSpellingMistake.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Fixtures\ClassesToTest;
+
+/**
+ * Spellling mistake in the interface documentation.
+ */
+interface InterfaceWithSpellingMistake
+{
+    public function methodWithTypoErorr(): string;
+}

--- a/tests/Fixtures/ClassesToTest/TraitWithTypo.php
+++ b/tests/Fixtures/ClassesToTest/TraitWithTypo.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Fixtures\ClassesToTest;
+
+/**
+ * Trait TraitWithTypo
+ *
+ * This trait is used to tst type errors in trait properties, methods, method parameters and trait documentation block.
+ *
+ * @internal
+ */
+trait TraitWithTypo
+{
+    public int $propertyWithoutSpellingMistake = 1;
+
+    public int $properytWithSpelllingMistake = 2;
+
+    private function methodWithoutSpellingMistakeInName(): void
+    {
+        // This is a method without a spelling mistake.
+    }
+
+    private function methodWithSpelllingMistakeInName(): void
+    {
+        // This is a method with a spelling mistake.
+    }
+
+    private function methodWithSpellingMistakeInParameters(string $spelllingMistakeInParameter): void
+    {
+        // This is a method with a spelling mistake in parameters.
+    }
+
+    private function methodWithoutSpellingMistakeInParameters(string $noSpellingMistakeInParameter): void
+    {
+        // This is a method without a spelling mistake in parameters.
+    }
+
+    /**
+     * This is a method with a spellling mistake in the doc block.
+     */
+    private function methodWithSpellingMistakeInDocBlock(): void
+    {
+        // This is a method with a spelling mistake in doc block.
+    }
+}

--- a/tests/Fixtures/EnumsToTest/BackendEnumWithTypoErrors.php
+++ b/tests/Fixtures/EnumsToTest/BackendEnumWithTypoErrors.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Fixtures\EnumsToTest;
+
+/**
+ * Even the documentation has spellling mistakes.
+ */
+enum BackendEnumWithTypoErrors: string
+{
+    case NO_SPELLING_MISTAKES = 'No spelling mistakes!';
+    case SPELLLING_MISTAKE_IN_CASE_NAME = 'Spelling mistake in case name';
+    case SPELLING_MISTAKE_IN_CASE_VALUE = 'Spellling mistake in case value';
+
+    private function methodWithoutSpellingMistakeInName(): void
+    {
+        // This is a method without a spelling mistake.
+    }
+
+    private function methodWithSpelllingMistakeInName(): void
+    {
+        // This is a method with a spelling mistake.
+    }
+
+    private function methodWithSpellingMistakeInParameters(string $spelllingMistakeInParameter): void
+    {
+        // This is a method with a spelling mistake in parameters.
+    }
+
+    private function methodWithoutSpellingMistakeInParameters(string $noSpellingMistakeInParameter): void
+    {
+        // This is a method without a spelling mistake in parameters.
+    }
+
+    /**
+     * This is a method with a spellling mistake in the doc block.
+     */
+    private function methodWithSpellingMistakeInDocBlock(): void
+    {
+        // This is a method with a spelling mistake in doc block.
+    }
+}

--- a/tests/Fixtures/EnumsToTest/FolderThatShouldBeIgnored/EnumWithTypoErrors.php
+++ b/tests/Fixtures/EnumsToTest/FolderThatShouldBeIgnored/EnumWithTypoErrors.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Fixtures\EnumsToTest\FolderThatShouldBeIgnored;
+
+enum EnumWithTypoErrors
+{
+    case CASE_WITH_SPELLLING_MISTAKE_IN_CASE_NAME;
+}

--- a/tests/Fixtures/EnumsToTest/UnitEnumWithTypoErrors.php
+++ b/tests/Fixtures/EnumsToTest/UnitEnumWithTypoErrors.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Fixtures\EnumsToTest;
+
+/**
+ * Even the documentation has spellling mistakes.
+ */
+enum UnitEnumWithTypoErrors
+{
+    case CASE_WITH_NO_SPELLING_MISTAKES;
+    case CASE_WITH_SPELLLING_MISTAKE_IN_CASE_NAME;
+
+    private function methodWithoutSpellingMistakeInName(): void
+    {
+        // This is a method without a spelling mistake.
+    }
+
+    private function methodWithSpelllingMistakeInName(): void
+    {
+        // This is a method with a spelling mistake.
+    }
+
+    private function methodWithSpellingMistakeInParameters(string $spelllingMistakeInParameter): void
+    {
+        // This is a method with a spelling mistake in parameters.
+    }
+
+    private function methodWithoutSpellingMistakeInParameters(string $noSpellingMistakeInParameter): void
+    {
+        // This is a method without a spelling mistake in parameters.
+    }
+
+    /**
+     * This is a method with a spellling mistake in the doc block.
+     */
+    private function methodWithSpellingMistakeInDocBlock(): void
+    {
+        // This is a method with a spelling mistake in doc block.
+    }
+}

--- a/tests/Unit/Checkers/FileSystemCheckerTest.php
+++ b/tests/Unit/Checkers/FileSystemCheckerTest.php
@@ -85,28 +85,67 @@ it('detects issues in the given directory, but ignores the whitelisted words', f
         'directory' => __DIR__.'/../../Fixtures',
     ]);
 
-    expect($issues)->toHaveCount(3)
-        ->and($issues[0]->file)->toEndWith('tests/Fixtures/FolderWithTypoos')
+    expect($issues)->toHaveCount(8)
+        ->and($issues[0]->file)->toEndWith('tests/Fixtures/EnumsToTest')
         ->and($issues[0]->line)->toBe(0)
-        ->and($issues[0]->misspelling->word)->toBe('typoos')
+        ->and($issues[0]->misspelling->word)->toBe('enums')
         ->and($issues[0]->misspelling->suggestions)->toBe([
+            'enemas',
+            'animus',
+            'emus',
+            'ems',
+        ])->and($issues[1]->file)->toEndWith('tests/Fixtures/EnumsToTest/BackendEnumWithTypoErrors.php')
+        ->and($issues[1]->line)->toBe(0)
+        ->and($issues[1]->misspelling->word)->toBe('backend')
+        ->and($issues[1]->misspelling->suggestions)->toBe([
+            'backed',
+            'bookend',
+            'back end',
+            'back-end',
+        ])->and($issues[2]->file)->toEndWith('tests/Fixtures/EnumsToTest/BackendEnumWithTypoErrors.php')
+        ->and($issues[2]->line)->toBe(0)
+        ->and($issues[2]->misspelling->word)->toBe('enum')
+        ->and($issues[2]->misspelling->suggestions)->toBe([
+            'enema',
+            'enemy',
+            'en um',
+            'en-um',
+        ])->and($issues[3]->file)->toEndWith('tests/Fixtures/EnumsToTest/FolderThatShouldBeIgnored/EnumWithTypoErrors.php')
+        ->and($issues[3]->line)->toBe(0)
+        ->and($issues[3]->misspelling->word)->toBe('enum')
+        ->and($issues[3]->misspelling->suggestions)->toBe([
+            'enema',
+            'enemy',
+            'en um',
+            'en-um',
+        ])->and($issues[4]->file)->toEndWith('tests/Fixtures/EnumsToTest/UnitEnumWithTypoErrors.php')
+        ->and($issues[4]->line)->toBe(0)
+        ->and($issues[4]->misspelling->word)->toBe('enum')
+        ->and($issues[4]->misspelling->suggestions)->toBe([
+            'enema',
+            'enemy',
+            'en um',
+            'en-um',
+        ])->and($issues[5]->file)->toEndWith('tests/Fixtures/FolderWithTypoos')
+        ->and($issues[5]->line)->toBe(0)
+        ->and($issues[5]->misspelling->word)->toBe('typoos')
+        ->and($issues[5]->misspelling->suggestions)->toBe([
             'typos',
             'typo\'s',
             'types',
             'type\'s',
-        ])->and($issues[1]->file)->toEndWith('tests/Fixtures/FolderWithTypoos/FileWithTppyo.php')
-        ->and($issues[1]->line)->toBe(0)
-        ->and($issues[1]->misspelling->word)->toBe('tppyo')
-        ->and($issues[1]->misspelling->suggestions)->toBe([
+        ])->and($issues[6]->file)->toEndWith('tests/Fixtures/FolderWithTypoos/FileWithTppyo.php')
+        ->and($issues[6]->line)->toBe(0)
+        ->and($issues[6]->misspelling->word)->toBe('tppyo')
+        ->and($issues[6]->misspelling->suggestions)->toBe([
             'typo',
             'Tokyo',
             'typos',
             'topi',
-        ])
-        ->and($issues[2]->file)->toEndWith('tests/Fixtures/FolderWithTypoos/FolderThatShouldBeIgnored/FileThatShoudBeIgnoredBecauseItsInsideWhitelistedFolder.php')
-        ->and($issues[2]->line)->toBe(0)
-        ->and($issues[2]->misspelling->word)->toBe('shoud')
-        ->and($issues[2]->misspelling->suggestions)->toBe([
+        ])->and($issues[7]->file)->toEndWith('tests/Fixtures/FolderWithTypoos/FolderThatShouldBeIgnored/FileThatShoudBeIgnoredBecauseItsInsideWhitelistedFolder.php')
+        ->and($issues[7]->line)->toBe(0)
+        ->and($issues[7]->misspelling->word)->toBe('shoud')
+        ->and($issues[7]->misspelling->suggestions)->toBe([
             'should',
             'shroud',
             'shod',

--- a/tests/Unit/Checkers/SourceCodeCheckerTest.php
+++ b/tests/Unit/Checkers/SourceCodeCheckerTest.php
@@ -22,7 +22,7 @@ it('does not detect issues in the given directory', function (): void {
     expect($issues)->toBeEmpty();
 });
 
-it('detects issues in the given directory', function (): void {
+it('detects issues in the given directory of classes', function (): void {
     $checker = new SourceCodeChecker(
         Config::instance(),
         InMemorySpellchecker::default(),
@@ -32,7 +32,7 @@ it('detects issues in the given directory', function (): void {
         'directory' => __DIR__.'/../../Fixtures/ClassesToTest',
     ]);
 
-    expect($issues)->toHaveCount(9)
+    expect($issues)->toHaveCount(17)
         ->and($issues[0]->file)->toEndWith('tests/Fixtures/ClassesToTest/ClassWithTypoErrors.php')
         ->and($issues[0]->line)->toBe(30)
         ->and($issues[0]->misspelling->word)->toBe('erorr')
@@ -105,10 +105,74 @@ it('detects issues in the given directory', function (): void {
             'propriety',
             'properer',
             'properest',
+        ])->and($issues[9]->file)->toEndWith('tests/Fixtures/ClassesToTest/InterfaceWithSpellingMistake.php')
+        ->and($issues[9]->line)->toBe(12)
+        ->and($issues[9]->misspelling->word)->toBe('erorr')
+        ->and($issues[9]->misspelling->suggestions)->toBe([
+            'error',
+            'errors',
+            'Orr',
+            'err',
+        ])->and($issues[10]->file)->toEndWith('tests/Fixtures/ClassesToTest/InterfaceWithSpellingMistake.php')
+        ->and($issues[10]->line)->toBe(8)
+        ->and($issues[10]->misspelling->word)->toBe('spellling')
+        ->and($issues[10]->misspelling->suggestions)->toBe([
+            'spelling',
+            'spilling',
+            'spell ling',
+            'spell-ling',
+        ])->and($issues[11]->file)->toEndWith('tests/Fixtures/ClassesToTest/TraitWithTypo.php')
+        ->and($issues[11]->line)->toBe(25)
+        ->and($issues[11]->misspelling->word)->toBe('spellling')
+        ->and($issues[11]->misspelling->suggestions)->toBe([
+            'spelling',
+            'spilling',
+            'spell ling',
+            'spell-ling',
+        ])->and($issues[12]->file)->toEndWith('tests/Fixtures/ClassesToTest/TraitWithTypo.php')
+        ->and($issues[12]->line)->toBe(30)
+        ->and($issues[12]->misspelling->word)->toBe('spellling')
+        ->and($issues[12]->misspelling->suggestions)->toBe([
+            'spelling',
+            'spilling',
+            'spell ling',
+            'spell-ling',
+        ])->and($issues[13]->file)->toEndWith('tests/Fixtures/ClassesToTest/TraitWithTypo.php')
+        ->and($issues[13]->line)->toBe(41)
+        ->and($issues[13]->misspelling->word)->toBe('spellling')
+        ->and($issues[13]->misspelling->suggestions)->toBe([
+            'spelling',
+            'spilling',
+            'spell ling',
+            'spell-ling',
+        ])->and($issues[14]->file)->toEndWith('tests/Fixtures/ClassesToTest/TraitWithTypo.php')
+        ->and($issues[14]->line)->toBe(18)
+        ->and($issues[14]->misspelling->word)->toBe('properyt')
+        ->and($issues[14]->misspelling->suggestions)->toBe([
+            'property',
+            'propriety',
+            'properer',
+            'properest',
+        ])->and($issues[15]->file)->toEndWith('tests/Fixtures/ClassesToTest/TraitWithTypo.php')
+        ->and($issues[15]->line)->toBe(18)
+        ->and($issues[15]->misspelling->word)->toBe('spellling')
+        ->and($issues[15]->misspelling->suggestions)->toBe([
+            'spelling',
+            'spilling',
+            'spell ling',
+            'spell-ling',
+        ])->and($issues[16]->file)->toEndWith('tests/Fixtures/ClassesToTest/TraitWithTypo.php')
+        ->and($issues[16]->line)->toBe(10)
+        ->and($issues[16]->misspelling->word)->toBe('tst')
+        ->and($issues[16]->misspelling->suggestions)->toBe([
+            'test',
+            'tat',
+            'ST',
+            'St',
         ]);
 });
 
-it('detects issues in the given directory, but ignores the whitelisted words', function (): void {
+it('detects issues in the given directory of classes, but ignores the whitelisted words', function (): void {
     $config = new Config(
         whitelistedWords: ['Properyt', 'bolck'],
     );
@@ -126,7 +190,7 @@ it('detects issues in the given directory, but ignores the whitelisted words', f
         'directory' => __DIR__.'/../../Fixtures/ClassesToTest',
     ]);
 
-    expect($issues)->toHaveCount(6)
+    expect($issues)->toHaveCount(13)
         ->and($issues[0]->file)->toEndWith('tests/Fixtures/ClassesToTest/ClassWithTypoErrors.php')
         ->and($issues[0]->line)->toBe(30)
         ->and($issues[0]->misspelling->word)->toBe('erorr')
@@ -159,10 +223,82 @@ it('detects issues in the given directory, but ignores the whitelisted words', f
             'tat',
             'ST',
             'St',
+        ])->and($issues[4]->file)->toEndWith('tests/Fixtures/ClassesToTest/ClassWithTypoOnConstants.php')
+        ->and($issues[4]->line)->toBe(11)
+        ->and($issues[4]->misspelling->word)->toBe('typoo')
+        ->and($issues[4]->misspelling->suggestions)->toBe([
+            'typo',
+            'typos',
+            'type',
+            'topi',
+        ])->and($issues[5]->file)->toEndWith('tests/Fixtures/ClassesToTest/ClassWithTypoOnConstants.php')
+        ->and($issues[5]->line)->toBe(11)
+        ->and($issues[5]->misspelling->word)->toBe('typoo')
+        ->and($issues[5]->misspelling->suggestions)->toBe([
+            'typo',
+            'typos',
+            'type',
+            'topi',
+        ])->and($issues[6]->file)->toEndWith('tests/Fixtures/ClassesToTest/InterfaceWithSpellingMistake.php')
+        ->and($issues[6]->line)->toBe(12)
+        ->and($issues[6]->misspelling->word)->toBe('erorr')
+        ->and($issues[6]->misspelling->suggestions)->toBe([
+            'error',
+            'errors',
+            'Orr',
+            'err',
+        ])->and($issues[7]->file)->toEndWith('tests/Fixtures/ClassesToTest/InterfaceWithSpellingMistake.php')
+        ->and($issues[7]->line)->toBe(8)
+        ->and($issues[7]->misspelling->word)->toBe('spellling')
+        ->and($issues[7]->misspelling->suggestions)->toBe([
+            'spelling',
+            'spilling',
+            'spell ling',
+            'spell-ling',
+        ])->and($issues[8]->file)->toEndWith('tests/Fixtures/ClassesToTest/TraitWithTypo.php')
+        ->and($issues[8]->line)->toBe(25)
+        ->and($issues[8]->misspelling->word)->toBe('spellling')
+        ->and($issues[8]->misspelling->suggestions)->toBe([
+            'spelling',
+            'spilling',
+            'spell ling',
+            'spell-ling',
+        ])->and($issues[9]->file)->toEndWith('tests/Fixtures/ClassesToTest/TraitWithTypo.php')
+        ->and($issues[9]->line)->toBe(30)
+        ->and($issues[9]->misspelling->word)->toBe('spellling')
+        ->and($issues[9]->misspelling->suggestions)->toBe([
+            'spelling',
+            'spilling',
+            'spell ling',
+            'spell-ling',
+        ])->and($issues[10]->file)->toEndWith('tests/Fixtures/ClassesToTest/TraitWithTypo.php')
+        ->and($issues[10]->line)->toBe(41)
+        ->and($issues[10]->misspelling->word)->toBe('spellling')
+        ->and($issues[10]->misspelling->suggestions)->toBe([
+            'spelling',
+            'spilling',
+            'spell ling',
+            'spell-ling',
+        ])->and($issues[11]->file)->toEndWith('tests/Fixtures/ClassesToTest/TraitWithTypo.php')
+        ->and($issues[11]->line)->toBe(18)
+        ->and($issues[11]->misspelling->word)->toBe('spellling')
+        ->and($issues[11]->misspelling->suggestions)->toBe([
+            'spelling',
+            'spilling',
+            'spell ling',
+            'spell-ling',
+        ])->and($issues[12]->file)->toEndWith('tests/Fixtures/ClassesToTest/TraitWithTypo.php')
+        ->and($issues[12]->line)->toBe(10)
+        ->and($issues[12]->misspelling->word)->toBe('tst')
+        ->and($issues[12]->misspelling->suggestions)->toBe([
+            'test',
+            'tat',
+            'ST',
+            'St',
         ]);
 });
 
-it('detects issues in the given directory, but ignores the whitelisted directories', function (): void {
+it('detects issues in the given directory of classes, but ignores the whitelisted directories', function (): void {
     $checker = new SourceCodeChecker(
         new Config(
             whitelistedDirectories: ['FolderThatShouldBeIgnored'],
@@ -174,7 +310,7 @@ it('detects issues in the given directory, but ignores the whitelisted directori
         'directory' => __DIR__.'/../../Fixtures/ClassesToTest',
     ]);
 
-    expect($issues)->toHaveCount(8)
+    expect($issues)->toHaveCount(16)
         ->and($issues[0]->file)->toEndWith('tests/Fixtures/ClassesToTest/ClassWithTypoErrors.php')
         ->and($issues[0]->line)->toBe(30)
         ->and($issues[0]->misspelling->word)->toBe('erorr')
@@ -223,6 +359,86 @@ it('detects issues in the given directory, but ignores the whitelisted directori
             'tat',
             'ST',
             'St',
+        ])->and($issues[6]->file)->toEndWith('tests/Fixtures/ClassesToTest/ClassWithTypoOnConstants.php')
+        ->and($issues[6]->line)->toBe(11)
+        ->and($issues[6]->misspelling->word)->toBe('typoo')
+        ->and($issues[6]->misspelling->suggestions)->toBe([
+            'typo',
+            'typos',
+            'type',
+            'topi',
+        ])->and($issues[7]->file)->toEndWith('tests/Fixtures/ClassesToTest/ClassWithTypoOnConstants.php')
+        ->and($issues[7]->line)->toBe(11)
+        ->and($issues[7]->misspelling->word)->toBe('typoo')
+        ->and($issues[7]->misspelling->suggestions)->toBe([
+            'typo',
+            'typos',
+            'type',
+            'topi',
+        ])->and($issues[8]->file)->toEndWith('tests/Fixtures/ClassesToTest/InterfaceWithSpellingMistake.php')
+        ->and($issues[8]->line)->toBe(12)
+        ->and($issues[8]->misspelling->word)->toBe('erorr')
+        ->and($issues[8]->misspelling->suggestions)->toBe([
+            'error',
+            'errors',
+            'Orr',
+            'err',
+        ])->and($issues[9]->file)->toEndWith('tests/Fixtures/ClassesToTest/InterfaceWithSpellingMistake.php')
+        ->and($issues[9]->line)->toBe(8)
+        ->and($issues[9]->misspelling->word)->toBe('spellling')
+        ->and($issues[9]->misspelling->suggestions)->toBe([
+            'spelling',
+            'spilling',
+            'spell ling',
+            'spell-ling',
+        ])->and($issues[10]->file)->toEndWith('tests/Fixtures/ClassesToTest/TraitWithTypo.php')
+        ->and($issues[10]->line)->toBe(25)
+        ->and($issues[10]->misspelling->word)->toBe('spellling')
+        ->and($issues[10]->misspelling->suggestions)->toBe([
+            'spelling',
+            'spilling',
+            'spell ling',
+            'spell-ling',
+        ])->and($issues[11]->file)->toEndWith('tests/Fixtures/ClassesToTest/TraitWithTypo.php')
+        ->and($issues[11]->line)->toBe(30)
+        ->and($issues[11]->misspelling->word)->toBe('spellling')
+        ->and($issues[11]->misspelling->suggestions)->toBe([
+            'spelling',
+            'spilling',
+            'spell ling',
+            'spell-ling',
+        ])->and($issues[12]->file)->toEndWith('tests/Fixtures/ClassesToTest/TraitWithTypo.php')
+        ->and($issues[12]->line)->toBe(41)
+        ->and($issues[12]->misspelling->word)->toBe('spellling')
+        ->and($issues[12]->misspelling->suggestions)->toBe([
+            'spelling',
+            'spilling',
+            'spell ling',
+            'spell-ling',
+        ])->and($issues[13]->file)->toEndWith('tests/Fixtures/ClassesToTest/TraitWithTypo.php')
+        ->and($issues[13]->line)->toBe(18)
+        ->and($issues[13]->misspelling->word)->toBe('properyt')
+        ->and($issues[13]->misspelling->suggestions)->toBe([
+            'property',
+            'propriety',
+            'properer',
+            'properest',
+        ])->and($issues[14]->file)->toEndWith('tests/Fixtures/ClassesToTest/TraitWithTypo.php')
+        ->and($issues[14]->line)->toBe(18)
+        ->and($issues[14]->misspelling->word)->toBe('spellling')
+        ->and($issues[14]->misspelling->suggestions)->toBe([
+            'spelling',
+            'spilling',
+            'spell ling',
+            'spell-ling',
+        ])->and($issues[15]->file)->toEndWith('tests/Fixtures/ClassesToTest/TraitWithTypo.php')
+        ->and($issues[15]->line)->toBe(10)
+        ->and($issues[15]->misspelling->word)->toBe('tst')
+        ->and($issues[15]->misspelling->suggestions)->toBe([
+            'test',
+            'tat',
+            'ST',
+            'St',
         ]);
 });
 
@@ -239,4 +455,260 @@ it('handles well when it can not detect the line problem', function (): void {
     $line = (fn (): int => $this->getErrorLine($splFileInfo, str_repeat('a', 100)))->call($checker);
 
     expect($line)->toBe(0);
+});
+
+it('detects issues in the given directory of enums', function (): void {
+    $checker = new SourceCodeChecker(
+        Config::instance(),
+        InMemorySpellchecker::default(),
+    );
+
+    $issues = $checker->check([
+        'directory' => __DIR__.'/../../Fixtures/EnumsToTest',
+    ]);
+
+    expect($issues)->toHaveCount(12)
+        ->and($issues[0]->file)->toEndWith('tests/Fixtures/EnumsToTest/BackendEnumWithTypoErrors.php')
+        ->and($issues[0]->line)->toBe(21)
+        ->and($issues[0]->misspelling->word)->toBe('spellling')
+        ->and($issues[0]->misspelling->suggestions)->toBe([
+            'spelling',
+            'spilling',
+            'spell ling',
+            'spell-ling',
+        ])
+        ->and($issues[1]->file)->toEndWith('tests/Fixtures/EnumsToTest/BackendEnumWithTypoErrors.php')
+        ->and($issues[1]->line)->toBe(26)
+        ->and($issues[1]->misspelling->word)->toBe('spellling')
+        ->and($issues[1]->misspelling->suggestions)->toBe([
+            'spelling',
+            'spilling',
+            'spell ling',
+            'spell-ling',
+        ])
+        ->and($issues[2]->file)->toEndWith('tests/Fixtures/EnumsToTest/BackendEnumWithTypoErrors.php')
+        ->and($issues[2]->line)->toBe(37)
+        ->and($issues[2]->misspelling->word)->toBe('spellling')
+        ->and($issues[2]->misspelling->suggestions)->toBe([
+            'spelling',
+            'spilling',
+            'spell ling',
+            'spell-ling',
+        ])
+        ->and($issues[3]->file)->toEndWith('tests/Fixtures/EnumsToTest/BackendEnumWithTypoErrors.php')
+        ->and($issues[3]->line)->toBe(13)
+        ->and($issues[3]->misspelling->word)->toBe('spellling')
+        ->and($issues[3]->misspelling->suggestions)->toBe([
+            'spelling',
+            'spilling',
+            'spell ling',
+            'spell-ling',
+        ])
+        ->and($issues[4]->file)->toEndWith('tests/Fixtures/EnumsToTest/BackendEnumWithTypoErrors.php')
+        ->and($issues[4]->line)->toBe(14)
+        ->and($issues[4]->misspelling->word)->toBe('spellling')
+        ->and($issues[4]->misspelling->suggestions)->toBe([
+            'spelling',
+            'spilling',
+            'spell ling',
+            'spell-ling',
+        ])
+        ->and($issues[5]->file)->toEndWith('tests/Fixtures/EnumsToTest/BackendEnumWithTypoErrors.php')
+        ->and($issues[5]->line)->toBe(8)
+        ->and($issues[5]->misspelling->word)->toBe('spellling')
+        ->and($issues[5]->misspelling->suggestions)->toBe([
+            'spelling',
+            'spilling',
+            'spell ling',
+            'spell-ling',
+        ])
+        ->and($issues[6]->file)->toEndWith('tests/Fixtures/EnumsToTest/FolderThatShouldBeIgnored/EnumWithTypoErrors.php')
+        ->and($issues[6]->line)->toBe(9)
+        ->and($issues[6]->misspelling->word)->toBe('spellling')
+        ->and($issues[6]->misspelling->suggestions)->toBe([
+            'spelling',
+            'spilling',
+            'spell ling',
+            'spell-ling',
+        ])
+        ->and($issues[7]->file)->toEndWith('tests/Fixtures/EnumsToTest/UnitEnumWithTypoErrors.php')
+        ->and($issues[7]->line)->toBe(20)
+        ->and($issues[7]->misspelling->word)->toBe('spellling')
+        ->and($issues[7]->misspelling->suggestions)->toBe([
+            'spelling',
+            'spilling',
+            'spell ling',
+            'spell-ling',
+        ])
+        ->and($issues[8]->file)->toEndWith('tests/Fixtures/EnumsToTest/UnitEnumWithTypoErrors.php')
+        ->and($issues[8]->line)->toBe(25)
+        ->and($issues[8]->misspelling->word)->toBe('spellling')
+        ->and($issues[8]->misspelling->suggestions)->toBe([
+            'spelling',
+            'spilling',
+            'spell ling',
+            'spell-ling',
+        ])
+        ->and($issues[9]->file)->toEndWith('tests/Fixtures/EnumsToTest/UnitEnumWithTypoErrors.php')
+        ->and($issues[9]->line)->toBe(36)
+        ->and($issues[9]->misspelling->word)->toBe('spellling')
+        ->and($issues[9]->misspelling->suggestions)->toBe([
+            'spelling',
+            'spilling',
+            'spell ling',
+            'spell-ling',
+        ])
+        ->and($issues[10]->file)->toEndWith('tests/Fixtures/EnumsToTest/UnitEnumWithTypoErrors.php')
+        ->and($issues[10]->line)->toBe(13)
+        ->and($issues[10]->misspelling->word)->toBe('spellling')
+        ->and($issues[10]->misspelling->suggestions)->toBe([
+            'spelling',
+            'spilling',
+            'spell ling',
+            'spell-ling',
+        ])
+        ->and($issues[11]->file)->toEndWith('tests/Fixtures/EnumsToTest/UnitEnumWithTypoErrors.php')
+        ->and($issues[11]->line)->toBe(8)
+        ->and($issues[11]->misspelling->word)->toBe('spellling')
+        ->and($issues[11]->misspelling->suggestions)->toBe([
+            'spelling',
+            'spilling',
+            'spell ling',
+            'spell-ling',
+        ]);
+});
+
+it('detects issues in the given directory of enums, but ignores the whitelisted words', function (): void {
+    $config = new Config(
+        whitelistedWords: ['spellling'],
+    );
+
+    $checker = new SourceCodeChecker(
+        $config,
+        new InMemorySpellchecker(
+            $config,
+            Aspell::create(),
+            Cache::default(),
+        ),
+    );
+
+    $issues = $checker->check([
+        'directory' => __DIR__.'/../../Fixtures/EnumsToTest',
+    ]);
+
+    expect($issues)->toBeEmpty();
+});
+
+it('detects issues in the given directory of enums, but ignores the whitelisted directories', function (): void {
+    $checker = new SourceCodeChecker(
+        new Config(
+            whitelistedDirectories: ['FolderThatShouldBeIgnored'],
+        ),
+        InMemorySpellchecker::default(),
+    );
+
+    $issues = $checker->check([
+        'directory' => __DIR__.'/../../Fixtures/EnumsToTest',
+    ]);
+
+    expect($issues)->toHaveCount(11)
+        ->and($issues[0]->file)->toEndWith('tests/Fixtures/EnumsToTest/BackendEnumWithTypoErrors.php')
+        ->and($issues[0]->line)->toBe(21)
+        ->and($issues[0]->misspelling->word)->toBe('spellling')
+        ->and($issues[0]->misspelling->suggestions)->toBe([
+            'spelling',
+            'spilling',
+            'spell ling',
+            'spell-ling',
+        ])
+        ->and($issues[1]->file)->toEndWith('tests/Fixtures/EnumsToTest/BackendEnumWithTypoErrors.php')
+        ->and($issues[1]->line)->toBe(26)
+        ->and($issues[1]->misspelling->word)->toBe('spellling')
+        ->and($issues[1]->misspelling->suggestions)->toBe([
+            'spelling',
+            'spilling',
+            'spell ling',
+            'spell-ling',
+        ])
+        ->and($issues[2]->file)->toEndWith('tests/Fixtures/EnumsToTest/BackendEnumWithTypoErrors.php')
+        ->and($issues[2]->line)->toBe(37)
+        ->and($issues[2]->misspelling->word)->toBe('spellling')
+        ->and($issues[2]->misspelling->suggestions)->toBe([
+            'spelling',
+            'spilling',
+            'spell ling',
+            'spell-ling',
+        ])
+        ->and($issues[3]->file)->toEndWith('tests/Fixtures/EnumsToTest/BackendEnumWithTypoErrors.php')
+        ->and($issues[3]->line)->toBe(13)
+        ->and($issues[3]->misspelling->word)->toBe('spellling')
+        ->and($issues[3]->misspelling->suggestions)->toBe([
+            'spelling',
+            'spilling',
+            'spell ling',
+            'spell-ling',
+        ])
+        ->and($issues[4]->file)->toEndWith('tests/Fixtures/EnumsToTest/BackendEnumWithTypoErrors.php')
+        ->and($issues[4]->line)->toBe(14)
+        ->and($issues[4]->misspelling->word)->toBe('spellling')
+        ->and($issues[4]->misspelling->suggestions)->toBe([
+            'spelling',
+            'spilling',
+            'spell ling',
+            'spell-ling',
+        ])
+        ->and($issues[5]->file)->toEndWith('tests/Fixtures/EnumsToTest/BackendEnumWithTypoErrors.php')
+        ->and($issues[5]->line)->toBe(8)
+        ->and($issues[5]->misspelling->word)->toBe('spellling')
+        ->and($issues[5]->misspelling->suggestions)->toBe([
+            'spelling',
+            'spilling',
+            'spell ling',
+            'spell-ling',
+        ])
+        ->and($issues[6]->file)->toEndWith('tests/Fixtures/EnumsToTest/UnitEnumWithTypoErrors.php')
+        ->and($issues[6]->line)->toBe(20)
+        ->and($issues[6]->misspelling->word)->toBe('spellling')
+        ->and($issues[6]->misspelling->suggestions)->toBe([
+            'spelling',
+            'spilling',
+            'spell ling',
+            'spell-ling',
+        ])
+        ->and($issues[7]->file)->toEndWith('tests/Fixtures/EnumsToTest/UnitEnumWithTypoErrors.php')
+        ->and($issues[7]->line)->toBe(25)
+        ->and($issues[7]->misspelling->word)->toBe('spellling')
+        ->and($issues[7]->misspelling->suggestions)->toBe([
+            'spelling',
+            'spilling',
+            'spell ling',
+            'spell-ling',
+        ])
+        ->and($issues[8]->file)->toEndWith('tests/Fixtures/EnumsToTest/UnitEnumWithTypoErrors.php')
+        ->and($issues[8]->line)->toBe(36)
+        ->and($issues[8]->misspelling->word)->toBe('spellling')
+        ->and($issues[8]->misspelling->suggestions)->toBe([
+            'spelling',
+            'spilling',
+            'spell ling',
+            'spell-ling',
+        ])
+        ->and($issues[9]->file)->toEndWith('tests/Fixtures/EnumsToTest/UnitEnumWithTypoErrors.php')
+        ->and($issues[9]->line)->toBe(13)
+        ->and($issues[9]->misspelling->word)->toBe('spellling')
+        ->and($issues[9]->misspelling->suggestions)->toBe([
+            'spelling',
+            'spilling',
+            'spell ling',
+            'spell-ling',
+        ])
+        ->and($issues[10]->file)->toEndWith('tests/Fixtures/EnumsToTest/UnitEnumWithTypoErrors.php')
+        ->and($issues[10]->line)->toBe(8)
+        ->and($issues[10]->misspelling->word)->toBe('spellling')
+        ->and($issues[10]->misspelling->suggestions)->toBe([
+            'spelling',
+            'spilling',
+            'spell ling',
+            'spell-ling',
+        ]);
 });

--- a/tests/Unit/Checkers/SourceCodeCheckerTest.php
+++ b/tests/Unit/Checkers/SourceCodeCheckerTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-use Peck\Checkers\ClassChecker;
+use Peck\Checkers\SourceCodeChecker;
 use Peck\Config;
 use Peck\Plugins\Cache;
 use Peck\Services\Spellcheckers\InMemorySpellchecker;
@@ -10,7 +10,7 @@ use PhpSpellcheck\Spellchecker\Aspell;
 use Symfony\Component\Finder\SplFileInfo;
 
 it('does not detect issues in the given directory', function (): void {
-    $checker = new ClassChecker(
+    $checker = new SourceCodeChecker(
         Config::instance(),
         InMemorySpellchecker::default(),
     );
@@ -23,7 +23,7 @@ it('does not detect issues in the given directory', function (): void {
 });
 
 it('detects issues in the given directory', function (): void {
-    $checker = new ClassChecker(
+    $checker = new SourceCodeChecker(
         Config::instance(),
         InMemorySpellchecker::default(),
     );
@@ -113,7 +113,7 @@ it('detects issues in the given directory, but ignores the whitelisted words', f
         whitelistedWords: ['Properyt', 'bolck'],
     );
 
-    $checker = new ClassChecker(
+    $checker = new SourceCodeChecker(
         $config,
         new InMemorySpellchecker(
             $config,
@@ -163,7 +163,7 @@ it('detects issues in the given directory, but ignores the whitelisted words', f
 });
 
 it('detects issues in the given directory, but ignores the whitelisted directories', function (): void {
-    $checker = new ClassChecker(
+    $checker = new SourceCodeChecker(
         new Config(
             whitelistedDirectories: ['FolderThatShouldBeIgnored'],
         ),
@@ -227,7 +227,7 @@ it('detects issues in the given directory, but ignores the whitelisted directori
 });
 
 it('handles well when it can not detect the line problem', function (): void {
-    $checker = new ClassChecker(
+    $checker = new SourceCodeChecker(
         new Config(
             whitelistedDirectories: ['FolderThatShouldBeIgnored'],
         ),

--- a/tests/Unit/ConfigTest.php
+++ b/tests/Unit/ConfigTest.php
@@ -21,6 +21,7 @@ it('should have a default configuration', function (): void {
         'formatter',
         'enum',
         'enums',
+        'backend',
     ])->and($config->whitelistedDirectories)->toBe([]);
 });
 
@@ -76,6 +77,7 @@ it('should not recreate a file that already exists', function (): void {
             'formatter',
             'enum',
             'enums',
+            'backend',
         ])
         ->and($config->whitelistedDirectories)->toBe([]);
 });

--- a/tests/Unit/ConfigTest.php
+++ b/tests/Unit/ConfigTest.php
@@ -19,6 +19,8 @@ it('should have a default configuration', function (): void {
         'php',
         'api',
         'formatter',
+        'enum',
+        'enums',
     ])->and($config->whitelistedDirectories)->toBe([]);
 });
 
@@ -72,6 +74,8 @@ it('should not recreate a file that already exists', function (): void {
             'php',
             'api',
             'formatter',
+            'enum',
+            'enums',
         ])
         ->and($config->whitelistedDirectories)->toBe([]);
 });

--- a/tests/Unit/KernelTest.php
+++ b/tests/Unit/KernelTest.php
@@ -11,5 +11,5 @@ it('handles multiple checkers', function (): void {
         'directory' => __DIR__.'/../Fixtures',
     ]);
 
-    expect($issues)->toHaveCount(13);
+    expect($issues)->toHaveCount(33);
 });


### PR DESCRIPTION
### What:

- [ ] Bug Fix
- [X] New Feature

### Description:

**This pull request adds full support for Enums, Traits and Interfaces!**

> Before creating a second pull request for the same feature, please try to give feedback here. Maybe we can simply add your suggestions or refactorings in this request instead of going through the same struggle as initially with the checkers


While working on this pull request, I found out that we already support Interfaces and Traits because ReflectionClass can be used for Interfaces as well!

Therefore, I simply added a complete test-suite for these type definitions!

**Edit:** The Test are currently failing, because I merged the main branch into this to resolve conflicts which then brought the new console check which at this point still has the problem with the line width. The other test previously passed!


```php
interface ExampleInterface
{
    public function exampleMethod(): void;
}

$reflection = new ReflectionClass(ExampleInterface::class);
var_dump($reflection->isInterface()); // bool(true)
var_dump($reflection->getMethods()[0]->getName()); // string(13) "exampleMethod"
```

Furthermore, while there is a `ReflectionEnum` class (which extends the `ReflectionClass`) we can also access the cases of an Enum through the `getConstants()` Method from a `ReflectionClass`. So UnitEnums were also already supported. To check the Values of BackendEnums I however had to slightly manipulate the Checker.

```php
enum BackendEnum: string
{
    // Cases
    case CASE_1 = 'VALUE_1';
    case CASE_2 = 'VALUE_2';

    // Constants
    const CASE_3 = 'VALUE_3';
}

$reflection = new ReflectionClass(BackendEnum::class);

foreach ($reflection->getConstants() as $case) {
    echo (($case instanceof BackedEnum) ? $case->value : $case).PHP_EOL;
}

// VALUE_1
// VALUE_2
// VALUE_3
```

I know, that the `SourceCodeChecker` class now does a lot!!!! But... The Code for all checkers is basically the same, as proven with this pull request. So we would just have a lot of duplicate code. One Idea to refactor this would be to outsource the `getXXXXName` functions into separate classes.

### Related:

- #49 
Had to recreate, due to weird behavior when resolving merge conflicts
