### PR TITLE
fix(misspelling-whitelist-filter): fix misspelling whitelisted words when getting it from cache

### DIFF
--- a/src/Services/Spellcheckers/Aspell.php
+++ b/src/Services/Spellcheckers/Aspell.php
@@ -48,7 +48,9 @@ final class Aspell implements Spellchecker
         /** @var array<int, Misspelling> $misspellings */
         $misspellings = $this->cache->has($text) ? $this->cache->get($text) : $this->getMisspellings($text);
 
-        return $misspellings;
+        return array_filter($misspellings,
+            fn (Misspelling $misspelling): bool => ! in_array(strtolower($misspelling->word), $this->config->whitelistedWords)
+        );
     }
 
     /**
@@ -59,10 +61,6 @@ final class Aspell implements Spellchecker
     private function getMisspellings(string $text): array
     {
         $misspellings = iterator_to_array($this->run($text));
-
-        $misspellings = array_filter($misspellings,
-            fn (Misspelling $misspelling): bool => ! in_array(strtolower($misspelling->word), $this->config->whitelistedWords)
-        );
 
         $this->cache->set($text, $misspellings);
 


### PR DESCRIPTION
### What:

- [x] Bug Fix

### Description:

Fixes the bug when changing the allowed words through the configuration file and keeps the cache.

Now the filtering of words is done after executing the command, or recovering an old execution from the cache. So even if the configuration file is changed, the cache will still be valid to be used with a new configuration.

### Related:

https://github.com/peckphp/peck/issues/76
