### PR TITLE
fix: checking code in extended class and traits

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -52,7 +52,7 @@
         "test:typos": "peck",
         "test:lint": "pint --test",
         "test:types": "phpstan analyse --ansi",
-        "test:unit": "pest --colors=always --coverage --exactly=98.2",
+        "test:unit": "pest --colors=always --coverage --exactly=98.3",
         "test": [
             "@test:refacto",
             "@test:lint",

--- a/tests/.pest/snapshots/Console/OutputTest/it_may_fail.snap
+++ b/tests/.pest/snapshots/Console/OutputTest/it_may_fail.snap
@@ -1,4 +1,4 @@
-  ..............................
+  .....................................
 
    Misspelling  [1m./tests/Fixtures/FolderWithTypoos[0m: '[1mtypoos[0m'  
   ./tests/Fixtures/FolderWithTypoos     
@@ -164,6 +164,46 @@
      8▕ [1m * Even the documentation has spellling mistakes.[0m  
         ------------------------------^     
   Did you mean: spelling, spilling, spieling, spellings  
+
+   Misspelling  [1m./tests/Fixtures/ParentAndTraits/ParentClass.php:13:26[0m: '[1mmetod[0m'  
+    13▕ [1m    public function parentMetodWithTypo(): void[0m  
+        --------------------------^     
+  Did you mean: method, meted, mated, muted  
+
+   Misspelling  [1m./tests/Fixtures/ParentAndTraits/ParentClass.php:11:25[0m: '[1mpropertt[0m'  
+    11▕ [1m    public string $parentProperttWithTypo = '';[0m  
+        -------------------------^     
+  Did you mean: property, proper, properer, properly  
+
+   Misspelling  [1m./tests/Fixtures/ParentAndTraits/ParentClass.php:9:22[0m: '[1mconstnat[0m'  
+     9▕ [1m    const PARENT_WITH_CONSTNAT_TYPE = 'parent_constantvaleu_typo';[0m  
+        ----------------------^     
+  Did you mean: constant, constants, consonant, consent  
+
+   Misspelling  [1m./tests/Fixtures/ParentAndTraits/ParentClass.php:9:46[0m: '[1mconstantvaleu[0m'  
+     9▕ [1m    const PARENT_WITH_CONSTNAT_TYPE = 'parent_constantvaleu_typo';[0m  
+        ----------------------------------------------^     
+  Did you mean: constantly, constantine, constants, constant  
+
+   Misspelling  [1m./tests/Fixtures/ParentAndTraits/UsedTrait.php:13:25[0m: '[1mmetod[0m'  
+    13▕ [1m    public function traitMetodWithTypo(): void[0m  
+        -------------------------^     
+  Did you mean: method, meted, mated, muted  
+
+   Misspelling  [1m./tests/Fixtures/ParentAndTraits/UsedTrait.php:11:24[0m: '[1mpropertt[0m'  
+    11▕ [1m    public string $traitProperttWithTypo = '';[0m  
+        ------------------------^     
+  Did you mean: property, proper, properer, properly  
+
+   Misspelling  [1m./tests/Fixtures/ParentAndTraits/UsedTrait.php:9:21[0m: '[1mconstnat[0m'  
+     9▕ [1m    const TRAIT_WITH_CONSTNAT_TYPE = 'trait_constantvaleu_typo';[0m  
+        ---------------------^     
+  Did you mean: constant, constants, consonant, consent  
+
+   Misspelling  [1m./tests/Fixtures/ParentAndTraits/UsedTrait.php:9:44[0m: '[1mconstantvaleu[0m'  
+     9▕ [1m    const TRAIT_WITH_CONSTNAT_TYPE = 'trait_constantvaleu_typo';[0m  
+        --------------------------------------------^     
+  Did you mean: constantly, constantine, constants, constant  
 
   Duration: 0.00s  
 

--- a/tests/Fixtures/ParentAndTraits/ChildClass.php
+++ b/tests/Fixtures/ParentAndTraits/ChildClass.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Fixtures\ParentAndTraits;
+
+final class ChildClass extends ParentClass
+{
+    use UsedTrait;
+}

--- a/tests/Fixtures/ParentAndTraits/ParentClass.php
+++ b/tests/Fixtures/ParentAndTraits/ParentClass.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Fixtures\ParentAndTraits;
+
+abstract class ParentClass
+{
+    const PARENT_WITH_CONSTNAT_TYPE = 'parent_constantvaleu_typo';
+
+    public string $parentProperttWithTypo = '';
+
+    public function parentMetodWithTypo(): void
+    {
+        //
+    }
+}

--- a/tests/Fixtures/ParentAndTraits/UsedTrait.php
+++ b/tests/Fixtures/ParentAndTraits/UsedTrait.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Fixtures\ParentAndTraits;
+
+trait UsedTrait
+{
+    const TRAIT_WITH_CONSTNAT_TYPE = 'trait_constantvaleu_typo';
+
+    public string $traitProperttWithTypo = '';
+
+    public function traitMetodWithTypo(): void
+    {
+        //
+    }
+}

--- a/tests/Unit/KernelTest.php
+++ b/tests/Unit/KernelTest.php
@@ -12,5 +12,5 @@ it('handles multiple checkers', function (): void {
         'onProgress' => fn (): null => null,
     ]);
 
-    expect($issues)->toHaveCount(33);
+    expect($issues)->toHaveCount(41);
 });


### PR DESCRIPTION
### What:

- [X] Bug Fix
- [ ] New Feature

### Description:
Redo of #70 
Now, checking that methods, properties and constants are not coming from traits too.

> Source Code checker was inspecting methods, properties, etc., in extended classes and traits. So it was reporting typos also in libraries, not only in the code of the project. 
> 
> Since it was not possible to find the typo in the current class, it was also reporting the misspelling with 0 (zero) value in the `line` property, which breaks the command output in `CheckCommand` [here](https://github.com/peckphp/peck/blob/77c282b5eb504f1cb0ddfb79fb67589a489483e7/src/Console/Commands/CheckCommand.php#L218).
> 

### Related:

https://github.com/peckphp/peck/issues/72
https://github.com/peckphp/peck/pull/70
