### PR TITLE
Fix(SpellcheckFormatter): Handle abbreviations - Resolves #65

### DIFF
--- a/src/Services/Spellcheckers/Aspell.php
+++ b/src/Services/Spellcheckers/Aspell.php
@@ -117,6 +117,7 @@ final class Aspell implements Spellchecker
             '--encoding',
             'utf-8',
             '-a',
+            '--ignore-case',
             '--lang=en_US',
         ]);
 

--- a/src/Support/SpellcheckFormatter.php
+++ b/src/Support/SpellcheckFormatter.php
@@ -21,6 +21,12 @@ final readonly class SpellcheckFormatter
         // Insert spaces between lowercase and uppercase letters (camelCase or PascalCase)
         $input = (string) preg_replace('/([a-z])([A-Z])/', '$1 $2', $input);
 
+        // Split sequences of uppercase letters, ensuring the last uppercase letter starts a new word
+        $input = (string) preg_replace('/([A-Z]+)([A-Z][a-z])/', '$1 $2', $input);
+
+        // Replace multiple spaces with a single space
+        $input = (string) preg_replace('/\s+/', ' ', $input);
+
         // Convert the final result to lowercase
         return strtolower($input);
     }

--- a/tests/Unit/Support/SpellcheckFormatterTest.php
+++ b/tests/Unit/Support/SpellcheckFormatterTest.php
@@ -39,3 +39,8 @@ it('can handle magic functions', function (): void {
 
     expect($result)->toBeString()->toBe('construct');
 });
+it('can handle abbreviations', function (): void {
+    $result = SpellcheckFormatter::format('getCountriesFromUSAAndEU');
+
+    expect($result)->toBeString()->toBe('get countries from usa and eu');
+});


### PR DESCRIPTION
### What:

- [x] Bug Fix
- [ ] New Feature

### Description:
As discussed in issue #65 and PRs #66 and #71, this PR adds more regex to split up words if there are abbreviations (e.g., [`getCountriesFromUSAAndEU`] will be split into [`get countries from usa and eu`]).

Since we enforce everything to be lowercase, I have also added [`--ignore-case`] to Aspell, as mentioned by @c0nst4ntin in a [comment](https://github.com/peckphp/peck/issues/65#issuecomment-2585381860) on #65.

Before
![Skjermbilde 2025-01-12 kl  02 12 01](https://github.com/user-attachments/assets/41a13caf-2d7c-4c65-8ee6-8ac3fd83ffc4)

After
![Skjermbilde 2025-01-12 kl  02 13 03](https://github.com/user-attachments/assets/ca7c17bd-4870-493d-988c-f18de83729ac)

It also have a test to check that it splits it up correctly
![Skjermbilde 2025-01-12 kl  02 19 04](https://github.com/user-attachments/assets/593b921f-608c-4492-b66a-eb929ddc0d21)

### Related:
Issue #65 False positives for abbreviations (e.g., 'USA', 'EU') due to forced lowercase in spell-check 
PR #66 Fix(NameParser): Handle abbreviations
PR #71 Fix(SpellcheckFormatter): Handle abbreviations
