### PR TITLE
Support Symfony 6.4 (LTS)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,8 +12,8 @@
     "require": {
         "php": "^8.3.0",
         "nunomaduro/termwind": "^2.3",
-        "symfony/console": "^7.2.1",
-        "symfony/finder": "^7.2.2"
+        "symfony/console": "^6.4 || ^7.2",
+        "symfony/finder": "^6.4 || ^7.2"
     },
     "require-dev": {
         "laravel/pint": "^1.19.0",


### PR DESCRIPTION
### What:

- [X] Bug Fix
- [ ] New Feature

### Description:

When installing peck with the current Symfony LTS version (6.4) composer runs into a problem with the console component.

Overview: [Symfony Versions](https://symfony.com/releases)

![Composer](https://github.com/user-attachments/assets/4cb4c415-b4df-4f36-aac4-470b277f53ad)

Not supporting the previous LTS ([which has received extended support until 2029](https://symfony.com/blog/symfony-5-4-lts-will-receive-security-fixes-until-february-2029-thanks-to-ibexa)) is okay for now. But we should at least support the current LTS

### Related:

- #83
