### PR TITLE
Added locale support for Aspell

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -35,7 +35,7 @@ final class Config
         public array $whitelistedWords = [],
         public array $whitelistedPaths = [],
         public ?string $preset = null,
-        public string $language = 'en_US',
+        public string $locale = 'en_US',
     ) {
         $this->whitelistedWords = array_map(strtolower(...), $whitelistedWords);
     }
@@ -88,7 +88,7 @@ final class Config
         /**
          * @var array{
          *     preset?: string,
-         *     language?: string,
+         *     locale?: string,
          *     ignore?: array{
          *         words?: array<int, string>,
          *         paths?: array<int, string>
@@ -101,7 +101,7 @@ final class Config
             $jsonAsArray['ignore']['words'] ?? [],
             $jsonAsArray['ignore']['paths'] ?? [],
             $jsonAsArray['preset'] ?? null,
-            $jsonAsArray['language'] ?? 'en_US',
+            $jsonAsArray['locale'] ?? 'en_US',
         );
     }
 

--- a/src/Config.php
+++ b/src/Config.php
@@ -35,6 +35,7 @@ final class Config
         public array $whitelistedWords = [],
         public array $whitelistedPaths = [],
         public ?string $preset = null,
+        public string $language = 'en_US',
     ) {
         $this->whitelistedWords = array_map(strtolower(...), $whitelistedWords);
     }
@@ -87,6 +88,7 @@ final class Config
         /**
          * @var array{
          *     preset?: string,
+         *     language?: string,
          *     ignore?: array{
          *         words?: array<int, string>,
          *         paths?: array<int, string>
@@ -99,6 +101,7 @@ final class Config
             $jsonAsArray['ignore']['words'] ?? [],
             $jsonAsArray['ignore']['paths'] ?? [],
             $jsonAsArray['preset'] ?? null,
+            $jsonAsArray['language'] ?? 'en_US',
         );
     }
 

--- a/src/Services/Spellcheckers/Aspell.php
+++ b/src/Services/Spellcheckers/Aspell.php
@@ -118,7 +118,7 @@ final class Aspell implements Spellchecker
             'utf-8',
             '-a',
             '--ignore-case',
-            "--lang={$this->config->language}",
+            "--lang={$this->config->locale}",
         ]);
 
         $process->setTimeout(0);

--- a/src/Services/Spellcheckers/Aspell.php
+++ b/src/Services/Spellcheckers/Aspell.php
@@ -118,7 +118,7 @@ final class Aspell implements Spellchecker
             'utf-8',
             '-a',
             '--ignore-case',
-            '--lang=en_US',
+            "--lang={$this->config->language}",
         ]);
 
         $process->setTimeout(0);

--- a/stubs/presets/laravel.stub
+++ b/stubs/presets/laravel.stub
@@ -1,0 +1,3 @@
+http
+laravel
+fillable

--- a/tests/.pest/snapshots/Console/OutputTest/it_may_fail.snap
+++ b/tests/.pest/snapshots/Console/OutputTest/it_may_fail.snap
@@ -1,4 +1,4 @@
-  .............⨯⨯⨯.⨯....⨯⨯.⨯⨯⨯⨯⨯⨯....⨯⨯
+  ...............⨯⨯⨯.⨯....⨯⨯⨯.⨯⨯⨯⨯⨯⨯....⨯⨯
 
    Misspelling  [1m./tests/Fixtures/FolderWithTypoos[0m: '[1mtypoos[0m'  
   ./tests/Fixtures/FolderWithTypoos     
@@ -19,6 +19,16 @@
   ./tests/Fixtures/FolderWithTypoos/FolderThatShouldBeIgnored/FileThatShoudBeIgnoredBecauseItsInsideWhitelistedFolder.php     
   --------------------------------------------------------------------^     
   Did you mean: should, shroud, shod, shout  
+
+   Misspelling  [1m./tests/Fixtures/BritishClassesToTest/ClassWithTypoOnConstants.php:9:20[0m: '[1mfavourite[0m'  
+     9▕ [1m    public const MY_FAVOURITE_CONSTANT = 'my favorite constant';[0m  
+        --------------------^     
+  Did you mean: favorite, favorites, favored, fluorite  
+
+   Misspelling  [1m./tests/Fixtures/BritishClassesToTest/ClassWithTypoOnConstants.php:11:29[0m: '[1mcolour[0m'  
+    11▕ [1m    public const ITS_WRITTEN_COLOUR = 'color';[0m  
+        -----------------------------^     
+  Did you mean: color, colo, cooler, coolie  
 
    Misspelling  [1m./tests/Fixtures/ClassesToTest/ClassWithTypoErrors.php:30:34[0m: '[1merorr[0m'  
     30▕ [1m    public function methodWithTypoErorr(): string[0m  

--- a/tests/Fixtures/BritishClassesToTest/ClassWithTypoOnConstants.php
+++ b/tests/Fixtures/BritishClassesToTest/ClassWithTypoOnConstants.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Fixtures\BritishClassesToTest;
+
+final class ClassWithTypoOnConstants
+{
+    public const MY_FAVOURITE_CONSTANT = 'my favorite constant';
+
+    public const ITS_WRITTEN_COLOUR = 'color';
+}

--- a/tests/Unit/Checkers/SourceCodeCheckerTest.php
+++ b/tests/Unit/Checkers/SourceCodeCheckerTest.php
@@ -762,17 +762,14 @@ it('should not verify the parent class', function (): void {
 
 it('detects issues with a different locale', function (): void {
     $config = new Config(
-        language: 'en_GB',
-    );
-    $cache = new Cache(
-        cacheDirectory: __DIR__.'/../../.peck-test.cache',
+        locale: 'en_GB',
     );
 
     $checker = new SourceCodeChecker(
         $config,
         new Aspell(
             $config,
-            $cache
+            Cache::default()
         ),
     );
 

--- a/tests/Unit/Checkers/SourceCodeCheckerTest.php
+++ b/tests/Unit/Checkers/SourceCodeCheckerTest.php
@@ -759,3 +759,46 @@ it('should not verify the parent class', function (): void {
         }
     }
 });
+
+it('detects issues with a different locale', function (): void {
+    $config = new Config(
+        language: 'en_GB',
+    );
+    $cache = new Cache(
+        cacheDirectory: __DIR__.'/../../.peck-test.cache',
+    );
+
+    $checker = new SourceCodeChecker(
+        $config,
+        new Aspell(
+            $config,
+            $cache
+        ),
+    );
+
+    $issues = $checker->check([
+        'directory' => __DIR__.'/../../Fixtures/BritishClassesToTest',
+        'onSuccess' => fn (): null => null,
+        'onFailure' => fn (): null => null,
+    ]);
+
+    expect($issues)->toHaveCount(2)
+        ->and($issues[0]->file)->toEndWith('tests/Fixtures/BritishClassesToTest/ClassWithTypoOnConstants.php')
+        ->and($issues[0]->line)->toBe(9)
+        ->and($issues[0]->misspelling->word)->toBe('favorite')
+        ->and($issues[0]->misspelling->suggestions)->toBe([
+            'favourite',
+            'favourites',
+            'favoured',
+            'fluorite',
+        ])
+        ->and($issues[1]->file)->toEndWith('tests/Fixtures/BritishClassesToTest/ClassWithTypoOnConstants.php')
+        ->and($issues[1]->line)->toBe(11)
+        ->and($issues[1]->misspelling->word)->toBe('color')
+        ->and($issues[1]->misspelling->suggestions)->toBe([
+            'colour',
+            'Colo',
+            'cool',
+            'Cole',
+        ]);
+});

--- a/tests/Unit/KernelTest.php
+++ b/tests/Unit/KernelTest.php
@@ -13,5 +13,5 @@ it('handles multiple checkers', function (): void {
         'onFailure' => fn (): null => null,
     ]);
 
-    expect($issues)->toHaveCount(41);
+    expect($issues)->toHaveCount(43);
 });


### PR DESCRIPTION
Example:
```json
{
    "locale": "en_GB"
}
```

My test is currently failing due to the cache if ran via `composer test` - frankly, no idea how to fix it right now. Running the test separately yields the expected results. Any help with this is highly appreciated.