### PR TITLE
fix: to prevent spell checking errors when a user home directory has …

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -7,6 +7,7 @@ namespace Peck;
 use Closure;
 use Peck\Support\PresetProvider;
 use Peck\Support\ProjectPath;
+use Peck\Support\SpellcheckFormatter;
 
 final class Config
 {
@@ -178,6 +179,8 @@ final class Config
      */
     private function ignoreWordsFromProjectPath(): array
     {
-        return explode(DIRECTORY_SEPARATOR, ProjectPath::get());
+        $directories = explode(DIRECTORY_SEPARATOR, ProjectPath::get());
+
+        return array_map(fn ($directory): string => SpellcheckFormatter::format($directory), array_filter($directories));
     }
 }

--- a/src/Config.php
+++ b/src/Config.php
@@ -151,6 +151,7 @@ final class Config
         return in_array(strtolower($word), [
             ...$this->whitelistedWords,
             ...PresetProvider::whitelistedWords($this->preset),
+            ...$this->ignoreWordsFromProjectPath(),
         ]);
     }
 
@@ -168,5 +169,15 @@ final class Config
                 'paths' => $this->whitelistedPaths,
             ],
         ], JSON_PRETTY_PRINT));
+    }
+
+    /**
+     * Ignore words from the project path including $HOME directory. Prevents spell check errors for cache constant
+     *
+     * @return list<string>
+     */
+    private function ignoreWordsFromProjectPath(): array
+    {
+        return explode(DIRECTORY_SEPARATOR, ProjectPath::get());
     }
 }

--- a/src/Plugins/Cache.php
+++ b/src/Plugins/Cache.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Peck\Plugins;
 
+use Peck\Support\ProjectPath;
 use RuntimeException;
 
 final readonly class Cache
@@ -27,7 +28,7 @@ final readonly class Cache
      */
     public static function default(): self
     {
-        $basePath = __DIR__.'/../../';
+        $basePath = ProjectPath::get();
 
         $cache = new self("{$basePath}/.peck.cache");
 


### PR DESCRIPTION
<!--
- Fill in the form below correctly. This will help the Peck team to understand the PR and also work on it.
-->

### What:

- [ ] Bug Fix

### Description:

When running the test suite locally, my home directory is atum which is seen as a mis-spelling. As we usaully exclude that part of the directory elsewhere, this issue only arrises on the constant check within the Cache class.

<img width="1323" alt="Screenshot 2025-01-13 at 09 31 35" src="https://github.com/user-attachments/assets/82e0c6f9-e82d-4aa9-826d-3a52d91b4563" />

To prevent this, we ensure that the project path is inferred within the class to match other code, and we also ignore those words that are found within the project directory base path.

<img width="613" alt="Screenshot 2025-01-13 at 12 32 01" src="https://github.com/user-attachments/assets/34d71f00-efb3-483b-9f5a-8a19a1fd24e2" />

Added in a similar way to presets

### Related:

<!-- link to the issue(s) your PR is solving. If it doesn't exist, remove the "Related" section. -->
