### PR TITLE
refactor: remove old additional reference to class loader to use new …

### DIFF
--- a/src/Console/Commands/CheckCommand.php
+++ b/src/Console/Commands/CheckCommand.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Peck\Console\Commands;
 
-use Composer\Autoload\ClassLoader;
 use Peck\Config;
 use Peck\Kernel;
+use Peck\Support\ProjectPath;
 use Peck\ValueObjects\Issue;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
@@ -164,7 +164,7 @@ final class CheckCommand extends Command
      */
     private function inferProjectPath(): string
     {
-        $basePath = dirname(array_keys(ClassLoader::getRegisteredLoaders())[0]);
+        $basePath = ProjectPath::get();
 
         return match (true) {
             isset($_ENV['APP_BASE_PATH']) => $_ENV['APP_BASE_PATH'],


### PR DESCRIPTION
<!--
- Fill in the form below correctly. This will help the Peck team to understand the PR and also work on it.
-->

### What:

Refactor

### Description:
Remove old additional reference to class loader to use new `ProjectPath` class

Check command has an infer project path method that references the class loader. As this is now within the new ProjectPath class, we can call `ProjectPath::get()` to remove duplication

<!-- describe what your PR is solving -->


