### PR TITLE
fix: phpdoc special characters

### DIFF
--- a/src/Support/SpellcheckFormatter.php
+++ b/src/Support/SpellcheckFormatter.php
@@ -16,7 +16,7 @@ final readonly class SpellcheckFormatter
         $input = ltrim($input, '_');
 
         // Replace special characters with spaces
-        $input = (string) preg_replace('/[!@#$%^&<>():.,\/\\\\_\-*]/', ' ', $input);
+        $input = (string) preg_replace('/[!@#$%^&<>():.|,\/\\\\_\-*]/', ' ', $input);
 
         // Insert spaces between lowercase and uppercase letters (camelCase or PascalCase)
         $input = (string) preg_replace('/([a-z])([A-Z])/', '$1 $2', $input);

--- a/src/Support/SpellcheckFormatter.php
+++ b/src/Support/SpellcheckFormatter.php
@@ -15,8 +15,8 @@ final readonly class SpellcheckFormatter
         // Remove leading underscores
         $input = ltrim($input, '_');
 
-        // Replace underscores and dashes with spaces
-        $input = str_replace(['_', '-'], ' ', $input);
+        // Replace special characters with spaces
+        $input = (string) preg_replace('/[!@#$%^&<>,\/\\\\_\-*]/', ' ', $input);
 
         // Insert spaces between lowercase and uppercase letters (camelCase or PascalCase)
         $input = (string) preg_replace('/([a-z])([A-Z])/', '$1 $2', $input);
@@ -28,6 +28,6 @@ final readonly class SpellcheckFormatter
         $input = (string) preg_replace('/\s+/', ' ', $input);
 
         // Convert the final result to lowercase
-        return strtolower($input);
+        return trim(strtolower($input));
     }
 }

--- a/src/Support/SpellcheckFormatter.php
+++ b/src/Support/SpellcheckFormatter.php
@@ -16,7 +16,7 @@ final readonly class SpellcheckFormatter
         $input = ltrim($input, '_');
 
         // Replace special characters with spaces
-        $input = (string) preg_replace('/[!@#$%^&<>,\/\\\\_\-*]/', ' ', $input);
+        $input = (string) preg_replace('/[!@#$%^&<>():.,\/\\\\_\-*]/', ' ', $input);
 
         // Insert spaces between lowercase and uppercase letters (camelCase or PascalCase)
         $input = (string) preg_replace('/([a-z])([A-Z])/', '$1 $2', $input);

--- a/tests/Unit/Support/SpellcheckFormatterTest.php
+++ b/tests/Unit/Support/SpellcheckFormatterTest.php
@@ -54,4 +54,34 @@ it('can handle special characters in phpdoc', function (string $input, $expected
     ['/** @use HasFactory<\Database\Factories\ClientFactory> */', 'use has factory database factories client factory'],
     ['/** @param array<value-of<Suit>, int> $count */', 'param array value of suit int count'],
     ['/** @var int<0, max> $number */', 'var int 0 max number'],
+    [
+        <<<'PHP'
+        /**
+         * This is the first line of the docblock.
+         * This is the second.
+         * @param array<value-of<Suit>, int> $count This is the description of the parameter
+         * which spans multiple lines.
+         */
+        PHP,
+        'this is the first line of the docblock this is the second param array value of suit int '
+        .'count this is the description of the parameter which spans multiple lines',
+    ],
+    [
+        <<<'PHP'
+        /**
+         * This docblock includes a description, tags, link and a deprecated notice.
+         *
+         * @param string $text The text to fetch.
+         * @param list<string> $options The options list.
+         * @param int<-1, max> $timeout The timeout value.
+         * @return string The fetched content.
+         * @link https://example.com
+         * @deprecated Use thatFunction() instead.
+         */
+        PHP,
+        'this docblock includes a description tags link and a deprecated notice param string text '
+        .'the text to fetch param list string options the options list param int 1 max timeout the '
+        .'timeout value return string the fetched content link https example com deprecated use '
+        .'that function instead',
+    ],
 ]);

--- a/tests/Unit/Support/SpellcheckFormatterTest.php
+++ b/tests/Unit/Support/SpellcheckFormatterTest.php
@@ -74,14 +74,14 @@ it('can handle special characters in phpdoc', function (string $input, $expected
          * @param string $text The text to fetch.
          * @param list<string> $options The options list.
          * @param int<-1, max> $timeout The timeout value.
-         * @return string The fetched content.
+         * @return string|null The fetched content.
          * @link https://example.com
          * @deprecated Use thatFunction() instead.
          */
         PHP,
         'this docblock includes a description tags link and a deprecated notice param string text '
         .'the text to fetch param list string options the options list param int 1 max timeout the '
-        .'timeout value return string the fetched content link https example com deprecated use '
-        .'that function instead',
+        .'timeout value return string null the fetched content link https example com deprecated '
+        .'use that function instead',
     ],
 ]);

--- a/tests/Unit/Support/SpellcheckFormatterTest.php
+++ b/tests/Unit/Support/SpellcheckFormatterTest.php
@@ -45,3 +45,13 @@ it('can handle abbreviations', function (): void {
 
     expect($result)->toBeString()->toBe('http controller');
 });
+
+it('can handle special characters in phpdoc', function (string $input, $expectedResult): void {
+    $result = SpellcheckFormatter::format($input);
+
+    expect($result)->toBeString()->toBe($expectedResult);
+})->with([
+    ['/** @use HasFactory<\Database\Factories\ClientFactory> */', 'use has factory database factories client factory'],
+    ['/** @param array<value-of<Suit>, int> $count */', 'param array value of suit int count'],
+    ['/** @var int<0, max> $number */', 'var int 0 max number'],
+]);


### PR DESCRIPTION
### What:

- [x] Bug Fix
- [ ] New Feature

### Description:

Found a bug where SpellcheckFormatter was not formatting correctly a phpdoc comments.
![image](https://github.com/user-attachments/assets/862127fd-f3d4-485f-98a2-66e32889b743)

Fixed by adding a regex to remove special characters like `\ / < > * @ $` in the SpellcheckFormatter.
