### PR TITLE
fix: this is an alternative approach to get the test suite working. I…

### DIFF
--- a/src/Support/PresetProvider.php
+++ b/src/Support/PresetProvider.php
@@ -13,7 +13,7 @@ final readonly class PresetProvider
     /**
      * The directory where the preset stubs are stored.
      */
-    private const string PRESET_STUBS_DIRECTORY = __DIR__.'/../../stubs/presets';
+    private const string PRESET_STUBS_DIRECTORY = '/stubs/presets';
 
     /**
      * Returns the whitelisted words for the given preset.
@@ -36,7 +36,7 @@ final readonly class PresetProvider
      */
     private static function getWordsFromStub(string $preset): array
     {
-        $path = sprintf('%s/%s.stub', self::PRESET_STUBS_DIRECTORY, $preset);
+        $path = sprintf('%s/%s.stub', self::getStubsPath(), $preset);
 
         return array_values(array_filter(array_map('trim', explode("\n", (string) file_get_contents($path)))));
     }
@@ -46,6 +46,14 @@ final readonly class PresetProvider
      */
     private static function stubExists(string $preset): bool
     {
-        return file_exists(sprintf('%s/%s.stub', self::PRESET_STUBS_DIRECTORY, $preset));
+        return file_exists(sprintf('%s/%s.stub', self::getStubsPath(), $preset));
+    }
+
+    /**
+     * Returns the real path from the relative path in the PRESET_STUBS_DIRECTORY constant
+     */
+    private static function getStubsPath(): string
+    {
+        return __DIR__.'/../../'.self::PRESET_STUBS_DIRECTORY;
     }
 }


### PR DESCRIPTION
<!--
- Fill in the form below correctly. This will help the Peck team to understand the PR and also work on it.
-->
### First

Please check #92 first as I believe this prevents future problems for other users

### What:

- [ ] Bug Fix

### Description:

When running the test suite locally, my home directory is atum which is seen as a mis-spelling. As we usually exclude that part of the directory elsewhere, this issue only arrises on the constant check within the Cache class.

<img width="1323" alt="Screenshot 2025-01-13 at 09 31 35" src="https://github.com/user-attachments/assets/82e0c6f9-e82d-4aa9-826d-3a52d91b4563" />

In #92, I add ignore words to the spell checker for the home directory to prevent this happening. In this PR, we simply extract it out.

### Related:

This is an alternative approach to the PR: #92 

<!-- link to the issue(s) your PR is solving. If it doesn't exist, remove the "Related" section. -->
