### PR TITLE
Update README.md for CI actions: check OS before running Peck, otherwise actions will fail if Aspell is not installed in that OS

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,13 @@ When running Peck on GitHub Actions, you can use the following workflow before r
           elif [[ "$RUNNER_OS" == "macOS" ]]; then
             brew install aspell
           fi
+
+    - name: Check Typos
+      shell: bash
+      run: |
+          if [[ "$RUNNER_OS" == "Linux" || "$RUNNER_OS" == "macOS" ]]; then
+            composer test:typos
+          fi
 ```
 
 ---


### PR DESCRIPTION
Aspell is installed only in Linux and macOS, so before executing Peck you must check that it is running in one of those OS's.

<!--
- Fill in the form below correctly. This will help the Peck team to understand the PR and also work on it.
-->

### What:

- [x] Bug Fix
- [ ] New Feature

### Description:

<!-- describe what your PR is solving -->

### Related:

<!-- link to the issue(s) your PR is solving. If it doesn't exist, remove the "Related" section. -->
