### PR TITLE
Refactor / Increase test coverage

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -75,10 +75,7 @@ final class Config
             return self::$instance;
         }
 
-        $basePath = ProjectPath::get();
-        $filePath = $basePath.'/'.(self::$resolveConfigFilePathUsing instanceof Closure
-                ? (self::$resolveConfigFilePathUsing)()
-                : self::JSON_CONFIGURATION_NAME);
+        $filePath = self::getResolvedFilePath();
 
         $contents = file_exists($filePath)
             ? (string) file_get_contents($filePath)
@@ -167,13 +164,23 @@ final class Config
      */
     private static function writeConfigFile(array $config): bool
     {
-        $filePath = ProjectPath::get().'/'.self::JSON_CONFIGURATION_NAME;
+        $filePath = self::getResolvedFilePath();
 
         if (file_exists($filePath)) {
             return false;
         }
 
         return (bool) file_put_contents($filePath, json_encode($config, JSON_PRETTY_PRINT));
+    }
+
+    /**
+     * returns the resolved config file path when a closure is available, or returns the default file in the project path
+     */
+    private static function getResolvedFilePath(): string
+    {
+        return self::$resolveConfigFilePathUsing instanceof Closure
+            ? (self::$resolveConfigFilePathUsing)()
+            : sprintf('%s/%s', ProjectPath::get(), self::JSON_CONFIGURATION_NAME);
     }
 
     /**

--- a/src/Plugins/Cache.php
+++ b/src/Plugins/Cache.php
@@ -85,7 +85,7 @@ final readonly class Cache
      */
     public function getCacheFile(string $key): string
     {
-        if (! is_dir($this->cacheDirectory) && ! mkdir($this->cacheDirectory, 0755, true)) {
+        if (! is_writable(dirname($this->cacheDirectory)) || (! is_dir($this->cacheDirectory) && ! mkdir($this->cacheDirectory, 0755, true))) {
             throw new RuntimeException("Could not create cache directory: {$this->cacheDirectory}");
         }
 

--- a/tests/Unit/ConfigTest.php
+++ b/tests/Unit/ConfigTest.php
@@ -55,3 +55,21 @@ it('should not recreate a file that already exists', function (): void {
         ])
         ->and($config->whitelistedPaths)->toBe([]);
 });
+
+it('can set ignore words', function (): void {
+    Config::flush();
+    $filePath = __DIR__.'/../Fixtures/peck.json';
+    Config::resolveConfigFilePathUsing(
+        fn (): string => $filePath,
+    );
+
+    Config::init();
+    $config = Config::instance();
+
+    expect($config->whitelistedWords)->toBe([]);
+
+    $config->ignoreWords(['laravel', 'paravel']);
+    Config::flush();
+
+    expect($config->whitelistedWords)->toBe(['laravel', 'paravel']);
+});

--- a/tests/Unit/ConfigTest.php
+++ b/tests/Unit/ConfigTest.php
@@ -31,9 +31,13 @@ it('should behave correctly even if the peck.json file does not exist', function
 });
 
 it('should be able to create a peck.json config file', function (): void {
-    $configFilePath = __DIR__.'/../../peck.json';
-    $backup = $configFilePath.'.backup';
-    rename($configFilePath, $backup);
+    if (file_exists($filePath = dirname(__DIR__).'/peck-new.json')) {
+        unlink($filePath);
+    }
+    Config::flush();
+    Config::resolveConfigFilePathUsing(
+        fn (): string => $filePath,
+    );
 
     $created = Config::init();
     $config = Config::instance();
@@ -42,8 +46,8 @@ it('should be able to create a peck.json config file', function (): void {
         ->and($config->whitelistedWords)->toBe(['php'])
         ->and($config->whitelistedPaths)->toBe([]);
 
-    rename($backup, $configFilePath);
-})->skip('rewrite this test a little bit differently without modifying the root level peck.json file');
+    unlink($filePath);
+});
 
 it('should not recreate a file that already exists', function (): void {
     $created = Config::init();
@@ -57,7 +61,9 @@ it('should not recreate a file that already exists', function (): void {
 });
 
 it('can set ignore words', function (): void {
-    unlink($filePath = dirname(__DIR__).'/peck-testing.json');
+    if (file_exists($filePath = dirname(__DIR__).'/peck-testing.json')) {
+        unlink($filePath);
+    }
     Config::flush();
     Config::resolveConfigFilePathUsing(
         fn (): string => $filePath,

--- a/tests/Unit/ConfigTest.php
+++ b/tests/Unit/ConfigTest.php
@@ -57,8 +57,8 @@ it('should not recreate a file that already exists', function (): void {
 });
 
 it('can set ignore words', function (): void {
+    unlink($filePath = dirname(__DIR__).'/peck-testing.json');
     Config::flush();
-    $filePath = __DIR__.'/../Fixtures/peck.json';
     Config::resolveConfigFilePathUsing(
         fn (): string => $filePath,
     );
@@ -66,10 +66,11 @@ it('can set ignore words', function (): void {
     Config::init();
     $config = Config::instance();
 
-    expect($config->whitelistedWords)->toBe([]);
+    expect($config->whitelistedWords)->toBe(['php']);
 
     $config->ignoreWords(['laravel', 'paravel']);
     Config::flush();
+    unlink($filePath);
 
-    expect($config->whitelistedWords)->toBe(['laravel', 'paravel']);
+    expect($config->whitelistedWords)->toBe(['php', 'laravel', 'paravel']);
 });


### PR DESCRIPTION
<!--
- Fill in the form below correctly. This will help the Peck team to understand the PR and also work on it.
-->

### What:

Refactor

### Description:

When attempting to increase the test coverage around flush cache I wanted to use a cache folder in a custom location which led me to noticing an opportunity to make the default config have a central location for change as well as one method for writing to the config, which can array merge changes from input.

The refactor helped the test to pass, and also means when new config is introduces, the init function and ignore words function are using an exact structure (similar to init) and it can be consistent.
