### PR TITLE
Error with no suggestions

### DIFF
--- a/src/Console/Commands/CheckCommand.php
+++ b/src/Console/Commands/CheckCommand.php
@@ -207,10 +207,7 @@ final class CheckCommand extends Command
                     <pre class="text-red-500 font-bold">{$alignSpacer}{$spacer}^</pre>
                 </div>
 
-                <div class="space-x-1 text-gray-700">
-                    <span>Did you mean:</span>
-                    <span class="font-bold">{$suggestions}</span>
-                </div>
+                {$suggestions}
             </div>
         HTML
         );
@@ -281,10 +278,7 @@ final class CheckCommand extends Command
                     <pre class="text-red-500 font-bold">{$spacer}^</pre>
                 </div>
 
-                <div class="space-x-1 text-gray-700">
-                    <span>Did you mean:</span>
-                    <span class="font-bold">{$suggestions}</span>
-                </div>
+                {$suggestions}
             </div>
         HTML);
     }
@@ -299,7 +293,25 @@ final class CheckCommand extends Command
             $issue->misspelling->suggestions,
         );
 
-        return implode(', ', $suggestions);
+        if ($suggestions === []) {
+            return <<<'HTML'
+                <div class="space-x-1 text-gray-700">
+                    <span class="font-bold">There are no suggestions for this misspelling.</span>
+                </div>
+            HTML;
+        }
+
+        $suggestionString = match (true) {
+            count($suggestions) > 1 => implode(', ', $suggestions),
+            default => $suggestions[0]
+        };
+
+        return <<<HTML
+            <div class="space-x-1 text-gray-700">
+                <span>Did you mean:</span>
+                <span class="font-bold">{$suggestionString}</span>
+            </div>
+        HTML;
     }
 
     /**

--- a/src/Services/Spellcheckers/Aspell.php
+++ b/src/Services/Spellcheckers/Aspell.php
@@ -97,14 +97,21 @@ final class Aspell implements Spellchecker
 
         $output = $process->getOutput();
 
-        return array_values(array_map(function (string $line): Misspelling {
+        return array_values(array_map(function (string $line) use ($text): Misspelling {
+            if (str_ends_with($line, '0') && ! str_contains($line, ':')) {
+                return new Misspelling($text, $this->takeSuggestions([]));
+            }
+
             [$wordMetadataAsString, $suggestionsAsString] = explode(':', trim($line));
 
             $word = explode(' ', $wordMetadataAsString)[1];
             $suggestions = explode(', ', trim($suggestionsAsString));
 
             return new Misspelling($word, $this->takeSuggestions($suggestions));
-        }, array_filter(explode(PHP_EOL, $output), fn (string $line): bool => str_starts_with($line, '&'))));
+        }, array_filter(
+            explode(PHP_EOL, $output),
+            fn (string $line): bool => ((str_starts_with($line, '&')) || str_ends_with($line, '0'))
+        )));
     }
 
     /**

--- a/tests/.pest/snapshots/Console/OutputTest/it_may_fail.snap
+++ b/tests/.pest/snapshots/Console/OutputTest/it_may_fail.snap
@@ -1,4 +1,4 @@
-  .............⨯⨯⨯.⨯....⨯⨯.⨯⨯⨯⨯⨯⨯....⨯⨯
+  ...............⨯⨯⨯.⨯....⨯⨯.⨯⨯⨯⨯⨯⨯⨯....⨯⨯
 
    Misspelling  [1m./tests/Fixtures/FolderWithTypoos[0m: '[1mtypoos[0m'  
   ./tests/Fixtures/FolderWithTypoos     
@@ -64,6 +64,11 @@
      9▕ [1m    public int $properytWithTypoError = 1;[0m  
         ----------------^     
   Did you mean: property, propriety, properer, properest  
+
+   Misspelling  [1m./tests/Fixtures/ClassesToTest/FolderThatShouldBeIgnored/DirectoryWithNoSuggestions/ClassWithNoSuggestions.php:9:20[0m: '[1msupercalifragilisticexpialidociouss[0m'  
+     9▕ [1m    public function supercalifragilisticexpialidociouss()[0m  
+        --------------------^     
+  There are no suggestions for this misspelling.  
 
    Misspelling  [1m./tests/Fixtures/ClassesToTest/InterfaceWithSpellingMistake.php:12:34[0m: '[1merorr[0m'  
     12▕ [1m    public function methodWithTypoErorr(): string;[0m  
@@ -205,7 +210,7 @@
         --------------------------------------------^     
   Did you mean: constantly, constantine, constants, constant  
 
-   FAIL  41 misspelling(s) found in your project.  
+   FAIL  42 misspelling(s) found in your project.  
     
   Duration: 0.00s   
   Hint: You may correct the misspellings individually, ignore them one by one, or ignore all of them using the peck --ignore-all option.  

--- a/tests/Console/OutputTest.php
+++ b/tests/Console/OutputTest.php
@@ -16,7 +16,7 @@ it('may fail', function (): void {
 
     expect($exitCode)->toBe(1)
         ->and($output)->toMatchSnapshot();
-});
+})->skip();
 
 it('may pass', function (): void {
     $process = Process::fromShellCommandline('./bin/peck');
@@ -30,4 +30,25 @@ it('may pass', function (): void {
 
     expect($exitCode)->toBe(0)
         ->and($output)->toMatchSnapshot();
+});
+
+it('tests for no suggestions', function (): void {
+    $process = Process::fromShellCommandline('./bin/peck check --path tests/Fixtures/ClassesToTest/FolderThatShouldBeIgnored/DirectoryWithNoSuggestions');
+
+    $exitCode = $process->run();
+
+    $output = $process->getOutput();
+    expect($exitCode)->toBe(1)
+        ->and($output)->toContain('There are no suggestions for this misspelling.');
+});
+
+it('tests multiple suggestions', function (): void {
+    $process = Process::fromShellCommandline('./bin/peck check --path tests/Fixtures');
+
+    $exitCode = $process->run();
+
+    $output = $process->getOutput();
+
+    expect($exitCode)->toBe(1)
+        ->and($output)->toContain('Did you mean: property, propriety, properer, properest');
 });

--- a/tests/Console/OutputTest.php
+++ b/tests/Console/OutputTest.php
@@ -16,7 +16,7 @@ it('may fail', function (): void {
 
     expect($exitCode)->toBe(1)
         ->and($output)->toMatchSnapshot();
-})->skip();
+});
 
 it('may pass', function (): void {
     $process = Process::fromShellCommandline('./bin/peck');

--- a/tests/Fixtures/ClassesToTest/FolderThatShouldBeIgnored/DirectoryWithNoSuggestions/ClassWithNoSuggestions.php
+++ b/tests/Fixtures/ClassesToTest/FolderThatShouldBeIgnored/DirectoryWithNoSuggestions/ClassWithNoSuggestions.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Fixtures\ClassesToTest\FolderThatShouldBeIgnored\DirectoryWithNoSuggestions;
+
+final class ClassWithNoSuggestions
+{
+    public function supercalifragilisticexpialidociouss()
+    {
+        return true;
+    }
+}

--- a/tests/Unit/Checkers/SourceCodeCheckerTest.php
+++ b/tests/Unit/Checkers/SourceCodeCheckerTest.php
@@ -36,7 +36,7 @@ it('detects issues in the given directory of classes', function (): void {
         'onFailure' => fn (): null => null,
     ]);
 
-    expect($issues)->toHaveCount(17)
+    expect($issues)->toHaveCount(18)
         ->and($issues[0]->file)->toEndWith('tests/Fixtures/ClassesToTest/ClassWithTypoErrors.php')
         ->and($issues[0]->line)->toBe(30)
         ->and($issues[0]->misspelling->word)->toBe('erorr')
@@ -109,24 +109,21 @@ it('detects issues in the given directory of classes', function (): void {
             'propriety',
             'properer',
             'properest',
-        ])->and($issues[9]->file)->toEndWith('tests/Fixtures/ClassesToTest/InterfaceWithSpellingMistake.php')
-        ->and($issues[9]->line)->toBe(12)
-        ->and($issues[9]->misspelling->word)->toBe('erorr')
-        ->and($issues[9]->misspelling->suggestions)->toBe([
+        ])->and($issues[9]->file)->toEndWith('tests/Fixtures/ClassesToTest/FolderThatShouldBeIgnored/DirectoryWithNoSuggestions/ClassWithNoSuggestions.php')
+        ->and($issues[9]->line)->toBe(9)
+        ->and($issues[9]->misspelling->word)->toBe('supercalifragilisticexpialidociouss')
+        ->and($issues[9]->misspelling->suggestions)->toBe([])
+
+        ->and($issues[10]->file)->toEndWith('tests/Fixtures/ClassesToTest/InterfaceWithSpellingMistake.php')
+        ->and($issues[10]->line)->toBe(12)
+        ->and($issues[10]->misspelling->word)->toBe('erorr')
+        ->and($issues[10]->misspelling->suggestions)->toBe([
             'error',
             'errors',
             'Orr',
             'err',
-        ])->and($issues[10]->file)->toEndWith('tests/Fixtures/ClassesToTest/InterfaceWithSpellingMistake.php')
-        ->and($issues[10]->line)->toBe(8)
-        ->and($issues[10]->misspelling->word)->toBe('spellling')
-        ->and($issues[10]->misspelling->suggestions)->toBe([
-            'spelling',
-            'spilling',
-            'spieling',
-            'spellings',
-        ])->and($issues[11]->file)->toEndWith('tests/Fixtures/ClassesToTest/TraitWithTypo.php')
-        ->and($issues[11]->line)->toBe(25)
+        ])->and($issues[11]->file)->toEndWith('tests/Fixtures/ClassesToTest/InterfaceWithSpellingMistake.php')
+        ->and($issues[11]->line)->toBe(8)
         ->and($issues[11]->misspelling->word)->toBe('spellling')
         ->and($issues[11]->misspelling->suggestions)->toBe([
             'spelling',
@@ -134,7 +131,7 @@ it('detects issues in the given directory of classes', function (): void {
             'spieling',
             'spellings',
         ])->and($issues[12]->file)->toEndWith('tests/Fixtures/ClassesToTest/TraitWithTypo.php')
-        ->and($issues[12]->line)->toBe(30)
+        ->and($issues[12]->line)->toBe(25)
         ->and($issues[12]->misspelling->word)->toBe('spellling')
         ->and($issues[12]->misspelling->suggestions)->toBe([
             'spelling',
@@ -142,7 +139,7 @@ it('detects issues in the given directory of classes', function (): void {
             'spieling',
             'spellings',
         ])->and($issues[13]->file)->toEndWith('tests/Fixtures/ClassesToTest/TraitWithTypo.php')
-        ->and($issues[13]->line)->toBe(41)
+        ->and($issues[13]->line)->toBe(30)
         ->and($issues[13]->misspelling->word)->toBe('spellling')
         ->and($issues[13]->misspelling->suggestions)->toBe([
             'spelling',
@@ -150,25 +147,33 @@ it('detects issues in the given directory of classes', function (): void {
             'spieling',
             'spellings',
         ])->and($issues[14]->file)->toEndWith('tests/Fixtures/ClassesToTest/TraitWithTypo.php')
-        ->and($issues[14]->line)->toBe(18)
-        ->and($issues[14]->misspelling->word)->toBe('properyt')
+        ->and($issues[14]->line)->toBe(41)
+        ->and($issues[14]->misspelling->word)->toBe('spellling')
         ->and($issues[14]->misspelling->suggestions)->toBe([
-            'property',
-            'propriety',
-            'properer',
-            'properest',
-        ])->and($issues[15]->file)->toEndWith('tests/Fixtures/ClassesToTest/TraitWithTypo.php')
-        ->and($issues[15]->line)->toBe(18)
-        ->and($issues[15]->misspelling->word)->toBe('spellling')
-        ->and($issues[15]->misspelling->suggestions)->toBe([
             'spelling',
             'spilling',
             'spieling',
             'spellings',
+        ])->and($issues[15]->file)->toEndWith('tests/Fixtures/ClassesToTest/TraitWithTypo.php')
+        ->and($issues[15]->line)->toBe(18)
+        ->and($issues[15]->misspelling->word)->toBe('properyt')
+        ->and($issues[15]->misspelling->suggestions)->toBe([
+            'property',
+            'propriety',
+            'properer',
+            'properest',
         ])->and($issues[16]->file)->toEndWith('tests/Fixtures/ClassesToTest/TraitWithTypo.php')
-        ->and($issues[16]->line)->toBe(10)
-        ->and($issues[16]->misspelling->word)->toBe('tst')
+        ->and($issues[16]->line)->toBe(18)
+        ->and($issues[16]->misspelling->word)->toBe('spellling')
         ->and($issues[16]->misspelling->suggestions)->toBe([
+            'spelling',
+            'spilling',
+            'spieling',
+            'spellings',
+        ])->and($issues[17]->file)->toEndWith('tests/Fixtures/ClassesToTest/TraitWithTypo.php')
+        ->and($issues[17]->line)->toBe(10)
+        ->and($issues[17]->misspelling->word)->toBe('tst')
+        ->and($issues[17]->misspelling->suggestions)->toBe([
             'test',
             'tat',
             'ST',
@@ -195,7 +200,7 @@ it('detects issues in the given directory of classes, but ignores the whiteliste
         'onFailure' => fn (): null => null,
     ]);
 
-    expect($issues)->toHaveCount(13)
+    expect($issues)->toHaveCount(14)
         ->and($issues[0]->file)->toEndWith('tests/Fixtures/ClassesToTest/ClassWithTypoErrors.php')
         ->and($issues[0]->line)->toBe(30)
         ->and($issues[0]->misspelling->word)->toBe('erorr')
@@ -244,24 +249,20 @@ it('detects issues in the given directory of classes, but ignores the whiteliste
             'typos',
             'type',
             'topi',
-        ])->and($issues[6]->file)->toEndWith('tests/Fixtures/ClassesToTest/InterfaceWithSpellingMistake.php')
-        ->and($issues[6]->line)->toBe(12)
-        ->and($issues[6]->misspelling->word)->toBe('erorr')
-        ->and($issues[6]->misspelling->suggestions)->toBe([
+        ])->and($issues[6]->file)->toEndWith('tests/Fixtures/ClassesToTest/FolderThatShouldBeIgnored/DirectoryWithNoSuggestions/ClassWithNoSuggestions.php')
+        ->and($issues[6]->line)->toBe(9)
+        ->and($issues[6]->misspelling->word)->toBe('supercalifragilisticexpialidociouss')
+        ->and($issues[6]->misspelling->suggestions)->toBe([])
+        ->and($issues[7]->file)->toEndWith('tests/Fixtures/ClassesToTest/InterfaceWithSpellingMistake.php')
+        ->and($issues[7]->line)->toBe(12)
+        ->and($issues[7]->misspelling->word)->toBe('erorr')
+        ->and($issues[7]->misspelling->suggestions)->toBe([
             'error',
             'errors',
             'Orr',
             'err',
-        ])->and($issues[7]->file)->toEndWith('tests/Fixtures/ClassesToTest/InterfaceWithSpellingMistake.php')
-        ->and($issues[7]->line)->toBe(8)
-        ->and($issues[7]->misspelling->word)->toBe('spellling')
-        ->and($issues[7]->misspelling->suggestions)->toBe([
-            'spelling',
-            'spilling',
-            'spieling',
-            'spellings',
-        ])->and($issues[8]->file)->toEndWith('tests/Fixtures/ClassesToTest/TraitWithTypo.php')
-        ->and($issues[8]->line)->toBe(25)
+        ])->and($issues[8]->file)->toEndWith('tests/Fixtures/ClassesToTest/InterfaceWithSpellingMistake.php')
+        ->and($issues[8]->line)->toBe(8)
         ->and($issues[8]->misspelling->word)->toBe('spellling')
         ->and($issues[8]->misspelling->suggestions)->toBe([
             'spelling',
@@ -269,7 +270,7 @@ it('detects issues in the given directory of classes, but ignores the whiteliste
             'spieling',
             'spellings',
         ])->and($issues[9]->file)->toEndWith('tests/Fixtures/ClassesToTest/TraitWithTypo.php')
-        ->and($issues[9]->line)->toBe(30)
+        ->and($issues[9]->line)->toBe(25)
         ->and($issues[9]->misspelling->word)->toBe('spellling')
         ->and($issues[9]->misspelling->suggestions)->toBe([
             'spelling',
@@ -277,7 +278,7 @@ it('detects issues in the given directory of classes, but ignores the whiteliste
             'spieling',
             'spellings',
         ])->and($issues[10]->file)->toEndWith('tests/Fixtures/ClassesToTest/TraitWithTypo.php')
-        ->and($issues[10]->line)->toBe(41)
+        ->and($issues[10]->line)->toBe(30)
         ->and($issues[10]->misspelling->word)->toBe('spellling')
         ->and($issues[10]->misspelling->suggestions)->toBe([
             'spelling',
@@ -285,7 +286,7 @@ it('detects issues in the given directory of classes, but ignores the whiteliste
             'spieling',
             'spellings',
         ])->and($issues[11]->file)->toEndWith('tests/Fixtures/ClassesToTest/TraitWithTypo.php')
-        ->and($issues[11]->line)->toBe(18)
+        ->and($issues[11]->line)->toBe(41)
         ->and($issues[11]->misspelling->word)->toBe('spellling')
         ->and($issues[11]->misspelling->suggestions)->toBe([
             'spelling',
@@ -293,9 +294,17 @@ it('detects issues in the given directory of classes, but ignores the whiteliste
             'spieling',
             'spellings',
         ])->and($issues[12]->file)->toEndWith('tests/Fixtures/ClassesToTest/TraitWithTypo.php')
-        ->and($issues[12]->line)->toBe(10)
-        ->and($issues[12]->misspelling->word)->toBe('tst')
+        ->and($issues[12]->line)->toBe(18)
+        ->and($issues[12]->misspelling->word)->toBe('spellling')
         ->and($issues[12]->misspelling->suggestions)->toBe([
+            'spelling',
+            'spilling',
+            'spieling',
+            'spellings',
+        ])->and($issues[13]->file)->toEndWith('tests/Fixtures/ClassesToTest/TraitWithTypo.php')
+        ->and($issues[13]->line)->toBe(10)
+        ->and($issues[13]->misspelling->word)->toBe('tst')
+        ->and($issues[13]->misspelling->suggestions)->toBe([
             'test',
             'tat',
             'ST',

--- a/tests/Unit/KernelTest.php
+++ b/tests/Unit/KernelTest.php
@@ -13,5 +13,5 @@ it('handles multiple checkers', function (): void {
         'onFailure' => fn (): null => null,
     ]);
 
-    expect($issues)->toHaveCount(41);
+    expect($issues)->toHaveCount(42);
 });


### PR DESCRIPTION
### What:

- [x] Bug Fix
- [ ] New Feature

### Description:

Right now, the Aspell class does not let us know when there are no suggestions for a misspelling. Instead, it returns as normal so the misspelling does not show

### Related:

#100 
