### PR TITLE
Fixes #104

### DIFF
--- a/src/Services/Spellcheckers/Aspell.php
+++ b/src/Services/Spellcheckers/Aspell.php
@@ -48,7 +48,7 @@ final class Aspell implements Spellchecker
         /** @var array<int, Misspelling> $misspellings */
         $misspellings = $this->cache->has($text) ? $this->cache->get($text) : $this->getMisspellings($text);
 
-        return array_filter($misspellings,
+        return array_filter($misspellings ?? [],
             fn (Misspelling $misspelling): bool => ! $this->config->isWordIgnored($misspelling->word),
         );
     }


### PR DESCRIPTION
### What:

- [x] Bug Fix
- [ ] New Feature

### Description:

Solves #104:

`PHP Fatal error:  Uncaught TypeError: array_filter(): Argument #1 ($array) must be of type array, null given in \vendor\peckphp\peck\src\Services\Spellcheckers\Aspell.php:51`