### PR TITLE
refactor: sort files with finder

### DIFF
--- a/src/Checkers/FileSystemChecker.php
+++ b/src/Checkers/FileSystemChecker.php
@@ -12,7 +12,6 @@ use Peck\Support\SpellcheckFormatter;
 use Peck\ValueObjects\Issue;
 use Peck\ValueObjects\Misspelling;
 use Symfony\Component\Finder\Finder;
-use Symfony\Component\Finder\SplFileInfo;
 
 /**
  * @internal
@@ -41,9 +40,8 @@ final readonly class FileSystemChecker implements Checker
             ->ignoreUnreadableDirs()
             ->ignoreVCSIgnored(true)
             ->in($parameters['directory'])
+            ->sortByName()
             ->getIterator());
-
-        usort($filesOrDirectories, fn (SplFileInfo $a, SplFileInfo $b): int => $a->getRealPath() <=> $b->getRealPath());
 
         $issues = [];
 

--- a/src/Checkers/SourceCodeChecker.php
+++ b/src/Checkers/SourceCodeChecker.php
@@ -51,9 +51,8 @@ final readonly class SourceCodeChecker implements Checker
             ->ignoreVCSIgnored(true)
             ->in($parameters['directory'])
             ->name('*.php')
+            ->sortByName()
             ->getIterator());
-
-        usort($sourceFiles, fn (SplFileInfo $a, SplFileInfo $b): int => $a->getRealPath() <=> $b->getRealPath());
 
         $issues = [];
 


### PR DESCRIPTION
<!--
- Fill in the form below correctly. This will help the Peck team to understand the PR and also work on it.
-->

### What:

- [ ] Bug Fix
- [ ] New Feature
- [x] Refactor

### Description:

Symfony Finder already provides a method to sort files. We don't need to implement our own.