### PR TITLE
Added more terms to the base and laravel presets

### DIFF
--- a/stubs/presets/base.stub
+++ b/stubs/presets/base.stub
@@ -91,3 +91,7 @@ sponsorship
 sponsorships
 iframe
 tokenize
+accessor
+backtrace
+nullable
+serializer

--- a/stubs/presets/laravel.stub
+++ b/stubs/presets/laravel.stub
@@ -1,0 +1,3 @@
+chaperone
+typesense
+jetstream


### PR DESCRIPTION
<!--
- Fill in the form below correctly. This will help the Peck team to understand the PR and also work on it.
-->

### What:

- [ ] Bug Fix
- [ ] New Feature
- [x] Preset addition

### Description:

I added the following terms to the base preset:
- `accessor`
- `backtrace`
- `nullable`
- `serializer`

And these to the laravel preset:
- `chaperone` (laravel model relation method)
- `jetstream` (first party laravel package)
- `typesense` (laravel scout integration)

I am happy to move the laravel ones into the base preset, but I consider at least `jetstream` and `typesense` to be more laravel-specific.

### Related:

I know there is a pending PR for alphabetical sorting of the terms, but to prevent confusion, I added mine to the end of the files.
