### PR TITLE
refactor: parallel processing

### DIFF
--- a/src/Services/Spellcheckers/Aspell.php
+++ b/src/Services/Spellcheckers/Aspell.php
@@ -75,6 +75,21 @@ final readonly class Aspell implements Spellchecker
     }
 
     /**
+     * Take the relevant suggestions from the given misspelling.
+     *
+     * @param  array<int, string>  $suggestions
+     * @return array<int, string>
+     */
+    private function takeSuggestions(array $suggestions): array
+    {
+        $suggestions = array_filter($suggestions,
+            fn (string $suggestion): bool => in_array(preg_match('/[^a-zA-Z]/', $suggestion), [0, false], true)
+        );
+
+        return array_slice(array_values(array_unique($suggestions)), 0, 4);
+    }
+
+    /**
      * Gets the misspellings from the given text.
      *
      * @return array<int, Misspelling>
@@ -125,20 +140,5 @@ final readonly class Aspell implements Spellchecker
 
             return array_merge($misspellings, $this->parseOutput($process->getOutput()));
         }, []);
-    }
-
-    /**
-     * Take the relevant suggestions from the given misspelling.
-     *
-     * @param  array<int, string>  $suggestions
-     * @return array<int, string>
-     */
-    private function takeSuggestions(array $suggestions): array
-    {
-        $suggestions = array_filter($suggestions,
-            fn (string $suggestion): bool => in_array(preg_match('/[^a-zA-Z]/', $suggestion), [0, false], true)
-        );
-
-        return array_slice(array_values(array_unique($suggestions)), 0, 4);
     }
 }


### PR DESCRIPTION
### What:

- [ ] Bug Fix
- [ ] New Feature

### Description:

Implemented parallel processing in the Aspell Spellchecker class, resulting in a 40% performance improvement on the first (non-cached) run.  

### Testing

To more easily test this, manually comment out caching in the Aspell class, run Pest while switching between main branch and this branch.

#### Test notes

**Main branch** with caching turned off
- 12.22s
- 11.97s
- 11.98s

**This branch** with caching turned off
- 8.20s
- 8.26s
- 8.24s