### PR TITLE
fix: misspelling should still be recognised as a misspelling when no suggestions are returned

### DIFF
--- a/src/Console/Commands/CheckCommand.php
+++ b/src/Console/Commands/CheckCommand.php
@@ -198,6 +198,8 @@ final class CheckCommand extends Command
             $issue,
         );
 
+        $suggestionsHelperText = ($suggestions > '') ? 'Did you mean:' : 'No suggestions found.';
+
         render(<<<HTML
             <div class="mx-2 mb-1">
                 <div class="space-x-1">
@@ -208,7 +210,7 @@ final class CheckCommand extends Command
                 </div>
 
                 <div class="space-x-1 text-gray-700">
-                    <span>Did you mean:</span>
+                    <span>{$suggestionsHelperText}</span>
                     <span class="font-bold">{$suggestions}</span>
                 </div>
             </div>
@@ -272,6 +274,8 @@ final class CheckCommand extends Command
             $issue,
         );
 
+        $suggestionsHelperText = ($suggestions > '') ? 'Did you mean:' : 'No suggestions found.';
+
         render(<<<HTML
             <div class="mx-2 mb-1">
                 <div class="space-x-1">
@@ -282,7 +286,7 @@ final class CheckCommand extends Command
                 </div>
 
                 <div class="space-x-1 text-gray-700">
-                    <span>Did you mean:</span>
+                    <span>{$suggestionsHelperText}</span>
                     <span class="font-bold">{$suggestions}</span>
                 </div>
             </div>

--- a/tests/.pest/snapshots/Console/OutputTest/it_may_fail.snap
+++ b/tests/.pest/snapshots/Console/OutputTest/it_may_fail.snap
@@ -1,4 +1,4 @@
-  .............⨯⨯⨯.⨯....⨯⨯.⨯⨯⨯⨯⨯⨯....⨯⨯
+  .............⨯⨯⨯.⨯......⨯⨯.⨯⨯⨯⨯⨯⨯....⨯⨯⨯
 
    Misspelling  [1m./tests/Fixtures/FolderWithTypoos[0m: '[1mtypoos[0m'  
   ./tests/Fixtures/FolderWithTypoos     
@@ -185,7 +185,12 @@
         ---------------------^     
   Did you mean: constant, constants, consonant, consent  
 
-   FAIL  37 misspelling(s) found in your project.  
+   Misspelling  [1m./tests/Fixtures/TypoNoSuggestions/ClassWithTypoErrors.php:16:48[0m: '[1mxxxxxxxxxxxxxxxxxxxx[0m'  
+    16▕ [1m    public int $propertyWithTypoAndNoSuggestionsXxxxxxxxxxxxxxxxxxxx = 1;[0m  
+        ------------------------------------------------^     
+  No suggestions found.   
+
+   FAIL  38 misspelling(s) found in your project.  
     
   Duration: 0.00s   
   Hint: You may correct the misspellings individually, ignore them one by one, or ignore all of them using the peck --ignore-all option.  

--- a/tests/Fixtures/TypoNoSuggestions/ClassWithTypoErrors.php
+++ b/tests/Fixtures/TypoNoSuggestions/ClassWithTypoErrors.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Fixtures\TypoNoSuggestions;
+
+/**
+ * Class ClassWithTypoErrors
+ *
+ * This class is used to test misspellings without suggestions.
+ *
+ * @internal
+ */
+final class ClassWithTypoErrors
+{
+    public int $propertyWithTypoAndNoSuggestionsXxxxxxxxxxxxxxxxxxxx = 1;
+}

--- a/tests/Unit/Checkers/SourceCodeCheckerTest.php
+++ b/tests/Unit/Checkers/SourceCodeCheckerTest.php
@@ -24,6 +24,26 @@ it('does not detect issues in the given directory', function (): void {
     expect($issues)->toBeEmpty();
 });
 
+it('detects issue and returns as fail when there are no suggestions', function (): void {
+    $checker = new SourceCodeChecker(
+        Config::instance(),
+        Aspell::default(),
+    );
+
+    $issues = $checker->check([
+        'directory' => __DIR__.'/../../Fixtures/TypoNoSuggestions',
+        'onSuccess' => fn (): null => null,
+        'onFailure' => fn (): null => null,
+    ]);
+
+    expect($issues)->toHaveCount(1)
+        ->and($issues[0]->file)->toEndWith('tests/Fixtures/TypoNoSuggestions/ClassWithTypoErrors.php')
+        ->and($issues[0]->line)->toBe(16)
+        ->and($issues[0]->misspelling->word)->toBe('xxxxxxxxxxxxxxxxxxxx')
+        ->and($issues[0]->misspelling->suggestions)->toBe([]);
+
+});
+
 it('detects issues in the given directory of classes', function (): void {
     $checker = new SourceCodeChecker(
         Config::instance(),

--- a/tests/Unit/KernelTest.php
+++ b/tests/Unit/KernelTest.php
@@ -13,5 +13,5 @@ it('handles multiple checkers', function (): void {
         'onFailure' => fn (): null => null,
     ]);
 
-    expect($issues)->toHaveCount(37);
+    expect($issues)->toHaveCount(38);
 });

--- a/tests/Unit/Services/AspellTest.php
+++ b/tests/Unit/Services/AspellTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use Peck\Config;
 use Peck\Plugins\Cache;
 use Peck\Services\Spellcheckers\Aspell;
+use Peck\ValueObjects\Misspelling;
 
 it('does not detect issues', function (): void {
     $spellchecker = Aspell::default();
@@ -90,4 +91,17 @@ it('gets correct issues with corrupted cache', function (): void {
     $issues = $spellchecker->check($cacheKey);
 
     expect($issues)->not->toBeEmpty();
+});
+
+it('reports a bad spelling even when there are no suggestions', function (): void {
+    Cache::default()->flush();
+    $spellchecker = Aspell::default();
+
+    $issues = $spellchecker->check('ppppppppppppppooihihihihih');
+
+    expect($issues)->toBeArray()
+        ->and($issues[0]->word)->toBe('ppppppppppppppooihihihihih')
+        ->and($issues[0]->suggestions)->toBe([])
+        ->and($issues[0])->toBeInstanceOf(Misspelling::class);
+
 });


### PR DESCRIPTION
…

<!--
- Fill in the form below correctly. This will help the Peck team to understand the PR and also work on it.
-->

### What:

- [ ] Bug Fix

### Description:
Fixes #100 

When a misspelling occurs, but no suggestions are found, the spellchecker returns as a pass. This is incorrect as the misspelling should still be reported.

<img width="599" alt="Screenshot 2025-01-18 at 14 53 38" src="https://github.com/user-attachments/assets/30ed6c7f-73a3-4cda-a7f4-fafef5dd28b5" />

results in:

<img width="477" alt="Screenshot 2025-01-18 at 14 54 54" src="https://github.com/user-attachments/assets/15375c31-4a76-4935-8158-07d9b0b7b36c" />


With this PR:

<img width="524" alt="Screenshot 2025-01-18 at 14 54 39" src="https://github.com/user-attachments/assets/6b5ea01f-342e-45d0-ba7a-a2ed5c34632d" />


<!-- describe what your PR is solving -->

### Related:

Issue #100 
Also just found #101 

<!-- link to the issue(s) your PR is solving. If it doesn't exist, remove the "Related" section. -->
