### PR TITLE
refactor: getConstantNames remove useless array flattening and improve filter order

### DIFF
--- a/src/Checkers/SourceCodeChecker.php
+++ b/src/Checkers/SourceCodeChecker.php
@@ -191,12 +191,13 @@ final readonly class SourceCodeChecker implements Checker
     {
         return array_map(
             fn (ReflectionClassConstant $constant): string => $constant->name,
-            array_filter(
+            array_values(array_filter(
                 $reflection->getReflectionConstants(),
                 function (ReflectionClassConstant $constant) use ($reflection): bool {
                     if ($constant->class !== $reflection->name) {
                         return false;
                     }
+
                     foreach ($reflection->getTraits() as $trait) {
                         if ($trait->hasConstant($constant->getName())) {
                             return false;
@@ -205,7 +206,7 @@ final readonly class SourceCodeChecker implements Checker
 
                     return true;
                 }
-            )
+            ))
         );
     }
 

--- a/src/Checkers/SourceCodeChecker.php
+++ b/src/Checkers/SourceCodeChecker.php
@@ -189,21 +189,24 @@ final readonly class SourceCodeChecker implements Checker
      */
     private function getConstantNames(ReflectionClass $reflection): array
     {
-        return array_merge(...array_values((array_map(
-            function (ReflectionClassConstant $constant) use ($reflection): array {
-                foreach ($reflection->getTraits() as $trait) {
-                    if ($trait->hasConstant($constant->getName())) {
-                        return [];
+        return array_map(
+            fn (ReflectionClassConstant $constant): string => $constant->name,
+            array_filter(
+                $reflection->getReflectionConstants(),
+                function (ReflectionClassConstant $constant) use ($reflection): bool {
+                    if ($constant->class !== $reflection->name) {
+                        return false;
                     }
-                }
-                if ($constant->class !== $reflection->name) {
-                    return [];
-                }
+                    foreach ($reflection->getTraits() as $trait) {
+                        if ($trait->hasConstant($constant->getName())) {
+                            return false;
+                        }
+                    }
 
-                return [$constant->name];
-            },
-            $reflection->getReflectionConstants()
-        ))));
+                    return true;
+                }
+            )
+        );
     }
 
     /**


### PR DESCRIPTION
### What:

- [ ] Bug Fix
- [ ] New Feature
- [x] Refactor

### Description:
Remove array flattening that is not necessary since 4f81fc4b887c9f7caa9033b3b57fa50957185c53.

Also, checking if the constant was declared in parent class is cheaper and can fail more frequently than checking if it was declared in traits. So we should check that first.