### PR TITLE
Set minimum php version to 8.2

### DIFF
--- a/.github/workflows/formats.yml
+++ b/.github/workflows/formats.yml
@@ -10,7 +10,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest]
-        php: [8.3]
+        php: [8.2]
         dependency-version: [prefer-lowest, prefer-stable]
 
     name: Formats P${{ matrix.php }} - ${{ matrix.os }} - ${{ matrix.dependency-version }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest, macos-latest]
-        php: ['8.3', '8.4']
+        php: ['8.2', '8.3', '8.4']
         symfony: ['^6.4', '^7.2']
         dependency-version: [prefer-lowest, prefer-stable]
 

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         }
     ],
     "require": {
-        "php": "^8.3.0",
+        "php": "^8.2",
         "nunomaduro/termwind": "^1.17.0|^2.3.0",
         "symfony/console": "^6.4.17|^7.2.1",
         "symfony/finder": "^6.4.17|^7.2.2"

--- a/src/Config.php
+++ b/src/Config.php
@@ -13,7 +13,7 @@ final class Config
     /**
      * The name of the configuration file.
      */
-    private const string JSON_CONFIGURATION_NAME = 'peck.json';
+    private const JSON_CONFIGURATION_NAME = 'peck.json';
 
     /**
      * The instance of the configuration.

--- a/src/Plugins/Cache.php
+++ b/src/Plugins/Cache.php
@@ -11,7 +11,7 @@ final readonly class Cache
     /**
      * The version of the cache.
      */
-    private const int VERSION = 1;
+    private const VERSION = 1;
 
     /**
      * Creates a new instance of Cache.

--- a/src/Support/PresetProvider.php
+++ b/src/Support/PresetProvider.php
@@ -13,7 +13,7 @@ final readonly class PresetProvider
     /**
      * The directory where the preset stubs are stored.
      */
-    private const string PRESET_STUBS_DIRECTORY = __DIR__.'/../../stubs/presets';
+    private const PRESET_STUBS_DIRECTORY = __DIR__.'/../../stubs/presets';
 
     /**
      * Returns the whitelisted words for the given preset.


### PR DESCRIPTION
### What:

- [ ] Bug Fix
- [x] New Feature

### Description:

This PR attempts to reduce the minimum supported php version to 8.2, to keep in step with Laravel's php support.

### Related:

This would close  issue #133 
