### PR TITLE
[Config] Multiple presets in config

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Here's an example configuration:
 
 ```json
 {
-    "preset": "laravel",
+    "preset": ["laravel"],
     "ignore": {
         "words": [
             "config",
@@ -105,7 +105,9 @@ You can also specify the path to the configuration file using the `--config` opt
 
 In order to make it easier to get started with Peck, we've included a few presets that you can use to ignore common words in your project. The following presets are available:
 
-- `laravel` 
+- `laravel` - Ignores common Laravel words such as `inertia`, `jetstream`, etc. 
+- `iso3166` - Ignores all ISO 3166 country codes in alpha-2 and alpha-3 format (e.g., `US`, `USA`, `GB`, `GBR`, etc.)
+- `iso4217` - Ignores all ISO 4217 currency codes (e.g., `USD`, `EUR`, `GBP`, etc.)
 
 ## Command Options
 

--- a/tests/.pest/snapshots/Console/OutputTest/it_may_fail.snap
+++ b/tests/.pest/snapshots/Console/OutputTest/it_may_fail.snap
@@ -1,4 +1,4 @@
-  .............⨯⨯⨯.⨯....⨯⨯.⨯⨯⨯⨯⨯⨯....⨯⨯
+  .............⨯⨯⨯.⨯.....⨯⨯.⨯⨯⨯⨯⨯⨯....⨯⨯
 
    Misspelling  [1m./tests/Fixtures/FolderWithTypoos[0m: '[1mtypoos[0m'  
   ./tests/Fixtures/FolderWithTypoos     

--- a/tests/Fixtures/invalid-presets-peck.json
+++ b/tests/Fixtures/invalid-presets-peck.json
@@ -1,8 +1,5 @@
 {
-    "presets": [
-        "iso3166",
-        "iso4217"
-    ],
+    "presets": "base",
     "ignore": {
         "words": [
             "php"

--- a/tests/Unit/Checkers/FileSystemCheckerTest.php
+++ b/tests/Unit/Checkers/FileSystemCheckerTest.php
@@ -89,67 +89,27 @@ it('detects issues in the given directory, but ignores the whitelisted words', f
         'onFailure' => fn (): null => null,
     ]);
 
-    expect($issues)->toHaveCount(8)
-        ->and($issues[0]->file)->toEndWith('tests/Fixtures/EnumsToTest')
+    expect($issues)->toHaveCount(3)
+        ->and($issues[0]->file)->toEndWith('tests/Fixtures/FolderWithTypoos')
         ->and($issues[0]->line)->toBe(0)
-        ->and($issues[0]->misspelling->word)->toBe('enums')
+        ->and($issues[0]->misspelling->word)->toBe('typoos')
         ->and($issues[0]->misspelling->suggestions)->toBe([
-            'enemas',
-            'animus',
-            'emus',
-            'ems',
-        ])->and($issues[1]->file)->toEndWith('tests/Fixtures/EnumsToTest/BackendEnumWithTypoErrors.php')
-        ->and($issues[1]->line)->toBe(0)
-        ->and($issues[1]->misspelling->word)->toBe('backend')
-        ->and($issues[1]->misspelling->suggestions)->toBe([
-            'backed',
-            'bookend',
-            'blackened',
-            'beckoned',
-        ])->and($issues[2]->file)->toEndWith('tests/Fixtures/EnumsToTest/BackendEnumWithTypoErrors.php')
-        ->and($issues[2]->line)->toBe(0)
-        ->and($issues[2]->misspelling->word)->toBe('enum')
-        ->and($issues[2]->misspelling->suggestions)->toBe([
-            'enema',
-            'enemy',
-            'emu',
-            'anime',
-        ])->and($issues[3]->file)->toEndWith('tests/Fixtures/EnumsToTest/FolderThatShouldBeIgnored/EnumWithTypoErrors.php')
-        ->and($issues[3]->line)->toBe(0)
-        ->and($issues[3]->misspelling->word)->toBe('enum')
-        ->and($issues[3]->misspelling->suggestions)->toBe([
-            'enema',
-            'enemy',
-            'emu',
-            'anime',
-        ])->and($issues[4]->file)->toEndWith('tests/Fixtures/EnumsToTest/UnitEnumWithTypoErrors.php')
-        ->and($issues[4]->line)->toBe(0)
-        ->and($issues[4]->misspelling->word)->toBe('enum')
-        ->and($issues[4]->misspelling->suggestions)->toBe([
-            'enema',
-            'enemy',
-            'emu',
-            'anime',
-        ])->and($issues[5]->file)->toEndWith('tests/Fixtures/FolderWithTypoos')
-        ->and($issues[5]->line)->toBe(0)
-        ->and($issues[5]->misspelling->word)->toBe('typoos')
-        ->and($issues[5]->misspelling->suggestions)->toBe([
             'typos',
             'types',
             'tops',
             'poos',
-        ])->and($issues[6]->file)->toEndWith('tests/Fixtures/FolderWithTypoos/FileWithTppyo.php')
-        ->and($issues[6]->line)->toBe(0)
-        ->and($issues[6]->misspelling->word)->toBe('tppyo')
-        ->and($issues[6]->misspelling->suggestions)->toBe([
+        ])->and($issues[1]->file)->toEndWith('tests/Fixtures/FolderWithTypoos/FileWithTppyo.php')
+        ->and($issues[1]->line)->toBe(0)
+        ->and($issues[1]->misspelling->word)->toBe('tppyo')
+        ->and($issues[1]->misspelling->suggestions)->toBe([
             'typo',
             'Tokyo',
             'typos',
             'topi',
-        ])->and($issues[7]->file)->toEndWith('tests/Fixtures/FolderWithTypoos/FolderThatShouldBeIgnored/FileThatShoudBeIgnoredBecauseItsInsideWhitelistedFolder.php')
-        ->and($issues[7]->line)->toBe(0)
-        ->and($issues[7]->misspelling->word)->toBe('shoud')
-        ->and($issues[7]->misspelling->suggestions)->toBe([
+        ])->and($issues[2]->file)->toEndWith('tests/Fixtures/FolderWithTypoos/FolderThatShouldBeIgnored/FileThatShoudBeIgnoredBecauseItsInsideWhitelistedFolder.php')
+        ->and($issues[2]->line)->toBe(0)
+        ->and($issues[2]->misspelling->word)->toBe('shoud')
+        ->and($issues[2]->misspelling->suggestions)->toBe([
             'should',
             'shroud',
             'shod',

--- a/tests/Unit/ConfigTest.php
+++ b/tests/Unit/ConfigTest.php
@@ -59,3 +59,11 @@ it('should not recreate a file that already exists', function (): void {
             'tests',
         ]);
 });
+
+it('should throw an runtime exception if the presets are not an array', function (): void {
+    Config::resolveConfigFilePathUsing(
+        fn (): string => 'tests/Fixtures/invalid-presets-peck.json',
+    );
+
+    Config::instance();
+})->throws(RuntimeException::class, 'The presets must be an array with all the presets you want to use.');

--- a/tests/Unit/Support/PresetProviderTest.php
+++ b/tests/Unit/Support/PresetProviderTest.php
@@ -4,18 +4,19 @@ declare(strict_types=1);
 
 use Peck\Support\PresetProvider;
 
-it('returns an empty array when the preset is null', function (): void {
-    expect(PresetProvider::whitelistedWords(null))->toBe([]);
+it('returns only words from base preset when presets are not given', function (): void {
+    expect(PresetProvider::whitelistedWords())->toBe(PresetProvider::getWordsFromStub('base'));
 });
 
-it('returns an empty array when the preset is invalid', function (): void {
-    expect(PresetProvider::whitelistedWords('invalid'))->toBe([]);
+it('returns only words from base preset when all given presets are invalids', function (): void {
+    expect(PresetProvider::whitelistedWords(['invalid-one', 'invalid-two']))->toBe(PresetProvider::getWordsFromStub('base'));
 });
 
-it('returns the whitelisted words for the given preset', function (): void {
-    expect(PresetProvider::whitelistedWords('laravel'))->toContain(
-        'http',
-        'laravel',
-        'fillable',
+it('returns the whitelisted words for the given and base presets', function (): void {
+    expect(PresetProvider::whitelistedWords(['laravel', 'iso3166', 'iso4217']))->toContain(
+        'apa',
+        'USD',
+        'USA',
+        'https'
     );
 });


### PR DESCRIPTION
### What:

- [ ] Bug Fix
- [X] New Feature

### Description:

After [creating 2](https://github.com/peckphp/peck/pull/129) more stubs containing currency codes and country codes, the default peck preset started to have a lot of stuff that may be unnecessary for a project

This PR aims to change the configuration so that it is possible to use more than 1 preset at the same time, so the dev can choose which presets to use to ignore words by default

With this change, the base preset will always be used, and the user will be able to use extra presets if desired.

This PR contains a breaking change in the [`peck.json`](https://github.com/julio-cavallari/peck/blob/e053dc42a5389d3ca171d4d11ab0598a8cded51c/peck.json) file, where the `preset` property was renamed to `presets` to make more sense with what this property receives in this new version.

### Related:

https://github.com/peckphp/peck/issues/138
