### PR TITLE
Relax termwind constraint to support all stable 2.x versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": "^8.2",
-        "nunomaduro/termwind": "^1.17.0 || ^2.0.0",
+        "nunomaduro/termwind": "^1.17.0 | ^2.0.0",
         "symfony/console": "^6.4.17|^7.2.1",
         "symfony/finder": "^6.4.17|^7.2.2"
     },

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": "^8.2",
-        "nunomaduro/termwind": "^1.17.0|^2.3.0",
+        "nunomaduro/termwind": "^1.17.0 || ^2.0.0",
         "symfony/console": "^6.4.17|^7.2.1",
         "symfony/finder": "^6.4.17|^7.2.2"
     },


### PR DESCRIPTION

### What:

- [x] Bug Fix
- [ ] New Feature

### Description:

The current version constraint for `nunomaduro/termwind` excludes several stable v2.x releases such as `2.1.0`, and `2.2.0` which are widely used. This causes conflicts when installing peckphp/peck in some Laravel apps for example.

This PR updates the constraint to:

    "^1.17.0 | ^2.0"

This allows all stable Termwind versions (v2.0+) while preserving v1.17+ support.

### Notes:

If there’s a specific reason for requiring `^2.3.0` and above, please feel free to disregard or advise, I might have overlooked an intentional compatibility boundary.
