### PR TITLE
[Config]: Adding "language" as a setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,25 @@ In order to make it easier to get started with Peck, we've included a few preset
 
 - `laravel` 
 
+### Languages
+
+While by default `peck` verfies the spelling by using GNU Aspell's `en_US` language dictionary, you can optionally specify a different language to be passed using the "language" key in the configuration;
+
+```json
+{
+    "preset": "laravel",
+    "language": "en_GB-ise",
+    "ignore": {
+        "words": [
+            "config",
+            "namespace"
+        ]
+    }
+}
+```
+
+You can see a full list of available dictionaries using the command `aspell dump dicts`.
+
 ## Command Options
 
 The behaviour of `peck` can be modified with the following command options:

--- a/src/Config.php
+++ b/src/Config.php
@@ -93,6 +93,7 @@ final class Config
         /**
          * @var array{
          *     preset?: string,
+         *     language?: string,
          *     ignore?: array{
          *         words?: array<int, string>,
          *         paths?: array<int, string>

--- a/src/Config.php
+++ b/src/Config.php
@@ -16,6 +16,11 @@ final class Config
     private const JSON_CONFIGURATION_NAME = 'peck.json';
 
     /**
+     * The default language passed to Aspell.
+     */
+    private const DEFAULT_LANGUAGE = 'en_US';
+
+    /**
      * The instance of the configuration.
      */
     private static ?self $instance = null;
@@ -35,6 +40,7 @@ final class Config
         public array $whitelistedWords = [],
         public array $whitelistedPaths = [],
         public ?string $preset = null,
+        public ?string $language = null,
     ) {
         $this->whitelistedWords = array_map(strtolower(...), $whitelistedWords);
     }
@@ -99,6 +105,7 @@ final class Config
             $jsonAsArray['ignore']['words'] ?? [],
             $jsonAsArray['ignore']['paths'] ?? [],
             $jsonAsArray['preset'] ?? null,
+            $jsonAsArray['language'] ?? null,
         );
     }
 
@@ -155,6 +162,14 @@ final class Config
     }
 
     /**
+     * Retrieves the configured language or the default
+     */
+    public function getLanguage(): string
+    {
+        return $this->language ?? self::DEFAULT_LANGUAGE;
+    }
+
+    /**
      * Save the configuration to the file.
      */
     private function persist(): void
@@ -163,6 +178,7 @@ final class Config
 
         file_put_contents($filePath, json_encode([
             ...$this->preset !== null ? ['preset' => $this->preset] : [],
+            ...$this->language !== null ? ['language' => $this->language] : [],
             'ignore' => [
                 'words' => $this->whitelistedWords,
                 'paths' => $this->whitelistedPaths,

--- a/src/Services/Spellcheckers/Aspell.php
+++ b/src/Services/Spellcheckers/Aspell.php
@@ -122,7 +122,7 @@ final class Aspell implements Spellchecker
             'utf-8',
             '-a',
             '--ignore-case',
-            '--lang=en_US',
+            '--lang='.$this->config->getLanguage(),
         ]);
 
         $process->setTimeout(0);

--- a/tests/Unit/ConfigTest.php
+++ b/tests/Unit/ConfigTest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use Peck\Config;
+use Peck\Support\ProjectPath;
 
 it('should have a default configuration', function (): void {
     $config = Config::instance();
@@ -58,4 +59,35 @@ it('should not recreate a file that already exists', function (): void {
         ->and($config->whitelistedPaths)->toBe([
             'tests',
         ]);
+});
+
+describe('language', function (): void {
+    beforeEach(function (): void{
+        $configPath = "/temp.json";
+        $this->jsonPath = ProjectPath::get().$configPath;
+        Config::flush();
+        Config::resolveConfigFilePathUsing(fn() => $configPath);
+        $this->exampleConfig = [
+            'preset' => 'laravel',
+            'ignore' => [
+                'words' => [
+                    'config',
+                ],
+            ]
+       ];
+    });
+    it('should default to `en_US` when the language flag is not set in the json file', function (): void {
+        file_put_contents($this->jsonPath, json_encode($this->exampleConfig));
+        $config = Config::instance();
+        expect($config->getLanguage())->toBe('en_US');
+    });
+    it('should read the language flag from the json file', function (): void {
+        $this->exampleConfig['language'] = 'en_GB';
+        file_put_contents($this->jsonPath, json_encode($this->exampleConfig));
+        $config = Config::instance();
+        expect($config->getLanguage())->toBe('en_GB');
+    });
+    afterEach(function (): void {
+        unlink($this->jsonPath);
+    });
 });


### PR DESCRIPTION
### What:

- [ ] Bug Fix
- [x] New Feature

### Description:

Adding a new setting to the config, that lets you configure the language passed to the underlying aspell command