### PR TITLE
feat: include symfony process

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,12 @@
 {
     "name": "peckphp/peck",
     "description": "Peck is a powerful CLI tool designed to identify pure wording or spelling (grammar) mistakes in your codebase.",
-    "keywords": ["php", "codebase", "spelling", "checker"],
+    "keywords": [
+        "php",
+        "codebase",
+        "spelling",
+        "checker"
+    ],
     "license": "MIT",
     "authors": [
         {
@@ -13,7 +18,8 @@
         "php": "^8.2",
         "nunomaduro/termwind": "^1.17.0|^2.3.0",
         "symfony/console": "^6.4.17|^7.2.1",
-        "symfony/finder": "^6.4.17|^7.2.2"
+        "symfony/finder": "^6.4.17|^7.2.2",
+        "symfony/process": "^6.4.17|^7.2.2"
     },
     "require-dev": {
         "laravel/pint": "^1.20.0",


### PR DESCRIPTION
### What:
- [x] Bug Fix

### Description:
I tried to install peck into a non laravel/symfony project and it looks like it didn't include symfony process. this PR just explictly add process to composer since it's a requirement to run.


```
❯ composer require peckphp/peck --dev
./composer.json has been updated
Running composer update peckphp/peck
Loading composer repositories with package information
Updating dependencies
Lock file operations: 2 installs, 0 updates, 0 removals
  - Locking nunomaduro/termwind (v2.3.1)
  - Locking peckphp/peck (v0.1.3)
Writing lock file
Installing dependencies from lock file (including require-dev)
Package operations: 2 installs, 0 updates, 0 removals
  - Installing nunomaduro/termwind (v2.3.1): Extracting archive
  - Installing peckphp/peck (v0.1.3): Extracting archive
Generating autoload files
75 packages you are using are looking for funding.
Use the `composer fund` command to find out more!
No security vulnerability advisories found.
Using version ^0.1.3 for peckphp/peck
❯ composer why symfony/process

In BaseDependencyCommand.php line 103:

  Could not find package "symfony/process" in your project


depends [-r|--recursive] [-t|--tree] [--locked] [--] <package>

❯ ./vendor/bin/peck
  PHP Fatal error:  Uncaught Error: Class "Symfony\Component\Process\Process" not found in /home/vagrant/myproject/vendor/peckphp/peck/src/Services/Spellcheckers/Aspell.php:119
Stack trace:
#0 /home/vagrant/myproject/vendor/peckphp/peck/src/Services/Spellcheckers/Aspell.php(96): Peck\Services\Spellcheckers\Aspell->createProcess()
#1 /home/vagrant/myproject/vendor/peckphp/peck/src/Services/Spellcheckers/Aspell.php(67): Peck\Services\Spellcheckers\Aspell->run()
#2 /home/vagrant/myproject/vendor/peckphp/peck/src/Services/Spellcheckers/Aspell.php(49): Peck\Services\Spellcheckers\Aspell->getMisspellings()
#3 /home/vagrant/myproject/vendor/peckphp/peck/src/Checkers/FileSystemChecker.php(56): Peck\Services\Spellcheckers\Aspell->check()
#4 /home/vagrant/myproject/vendor/peckphp/peck/src/Kernel.php(53): Peck\Checkers\FileSystemChecker->check()
#5 /home/vagrant/myproject/vendor/peckphp/peck/src/Console/Commands/CheckCommand.php(60): Peck\Kernel->handle()
#6 /home/vagrant/myproject/vendor/symfony/console/Command/Command.php(318): Peck\Console\Commands\CheckCommand->execute()
#7 /home/vagrant/myproject/vendor/symfony/console/Application.php(1074): Symfony\Component\Console\Command\Command->run()
#8 /home/vagrant/myproject/vendor/symfony/console/Application.php(341): Symfony\Component\Console\Application->doRunCommand()
#9 /home/vagrant/myproject/vendor/symfony/console/Application.php(192): Symfony\Component\Console\Application->doRun()
#10 /home/vagrant/myproject/vendor/peckphp/peck/bin/peck(31): Symfony\Component\Console\Application->run()
#11 /home/vagrant/myproject/vendor/bin/peck(119): include('...')
#12 {main}
  thrown in /home/vagrant/myproject/vendor/peckphp/peck/src/Services/Spellcheckers/Aspell.php on line 119

Fatal error: Uncaught Error: Class "Symfony\Component\Process\Process" not found in /home/vagrant/myproject/vendor/peckphp/peck/src/Services/Spellcheckers/Aspell.php:119
Stack trace:
#0 /home/vagrant/myproject/vendor/peckphp/peck/src/Services/Spellcheckers/Aspell.php(96): Peck\Services\Spellcheckers\Aspell->createProcess()
#1 /home/vagrant/myproject/vendor/peckphp/peck/src/Services/Spellcheckers/Aspell.php(67): Peck\Services\Spellcheckers\Aspell->run()
#2 /home/vagrant/myproject/vendor/peckphp/peck/src/Services/Spellcheckers/Aspell.php(49): Peck\Services\Spellcheckers\Aspell->getMisspellings()
#3 /home/vagrant/myproject/vendor/peckphp/peck/src/Checkers/FileSystemChecker.php(56): Peck\Services\Spellcheckers\Aspell->check()
#4 /home/vagrant/myproject/vendor/peckphp/peck/src/Kernel.php(53): Peck\Checkers\FileSystemChecker->check()
#5 /home/vagrant/myproject/vendor/peckphp/peck/src/Console/Commands/CheckCommand.php(60): Peck\Kernel->handle()
#6 /home/vagrant/myproject/vendor/symfony/console/Command/Command.php(318): Peck\Console\Commands\CheckCommand->execute()
#7 /home/vagrant/myproject/vendor/symfony/console/Application.php(1074): Symfony\Component\Console\Command\Command->run()
#8 /home/vagrant/myproject/vendor/symfony/console/Application.php(341): Symfony\Component\Console\Application->doRunCommand()
#9 /home/vagrant/myproject/vendor/symfony/console/Application.php(192): Symfony\Component\Console\Application->doRun()
#10 /home/vagrant/myproject/vendor/peckphp/peck/bin/peck(31): Symfony\Component\Console\Application->run()
#11 /home/vagrant/myproject/vendor/bin/peck(119): include('...')
#12 {main}
  thrown in /home/vagrant/myproject/vendor/peckphp/peck/src/Services/Spellcheckers/Aspell.php on line 119
```