### PR TITLE
[Aspell]: Handle misspellings with no Suggestions

### DIFF
--- a/src/Console/Commands/CheckCommand.php
+++ b/src/Console/Commands/CheckCommand.php
@@ -207,6 +207,10 @@ final class CheckCommand extends Command
             $issue,
         );
 
+        $suggestionText = $suggestions === '' || $suggestions === '0'
+            ? '<span>No suggestions available.</span>'
+            : "<span>Did you mean: <span class=\"font-bold\">{$suggestions}</span></span>";
+
         render(<<<HTML
             <div class="mx-2 mb-1">
                 <div class="space-x-1">
@@ -217,8 +221,7 @@ final class CheckCommand extends Command
                 </div>
 
                 <div class="space-x-1 text-gray-700">
-                    <span>Did you mean:</span>
-                    <span class="font-bold">{$suggestions}</span>
+                    {$suggestionText}
                 </div>
             </div>
         HTML
@@ -281,6 +284,10 @@ final class CheckCommand extends Command
             $issue,
         );
 
+        $suggestionText = $suggestions === '' || $suggestions === '0'
+            ? '<span>No suggestions available.</span>'
+            : "<span>Did you mean: <span class=\"font-bold\">{$suggestions}</span></span>";
+
         render(<<<HTML
             <div class="mx-2 mb-1">
                 <div class="space-x-1">
@@ -291,8 +298,7 @@ final class CheckCommand extends Command
                 </div>
 
                 <div class="space-x-1 text-gray-700">
-                    <span>Did you mean:</span>
-                    <span class="font-bold">{$suggestions}</span>
+                    {$suggestionText}
                 </div>
             </div>
         HTML);
@@ -307,6 +313,10 @@ final class CheckCommand extends Command
             $issue,
         );
 
+        $suggestionText = $suggestions === '' || $suggestions === '0'
+            ? '<span>No suggestions available.</span>'
+            : "<span>Did you mean: <span class=\"font-bold\">{$suggestions}</span></span>";
+
         render(<<<HTML
             <div class="mx-2 mt-1 space-y-1">
                 <div class="space-x-1">
@@ -315,8 +325,7 @@ final class CheckCommand extends Command
                 </div>
 
                 <div class="space-x-1 text-gray-700">
-                    <span>Did you mean:</span>
-                    <span class="font-bold">{$suggestions}</span>
+                    {$suggestionText}
                 </div>
             </div>
             HTML

--- a/src/Services/Spellcheckers/Aspell.php
+++ b/src/Services/Spellcheckers/Aspell.php
@@ -52,7 +52,8 @@ final class Aspell implements Spellchecker
             $misspellings = $this->getMisspellings($text);
         }
 
-        return array_filter($misspellings,
+        return array_filter(
+            $misspellings,
             fn (Misspelling $misspelling): bool => ! $this->config->isWordIgnored($misspelling->word),
         );
     }
@@ -64,7 +65,7 @@ final class Aspell implements Spellchecker
      */
     private function getMisspellings(string $text): array
     {
-        $misspellings = iterator_to_array($this->run($text));
+        $misspellings = $this->run($text);
 
         $this->cache->set($text, $misspellings);
 
@@ -79,7 +80,8 @@ final class Aspell implements Spellchecker
      */
     private function takeSuggestions(array $suggestions): array
     {
-        $suggestions = array_filter($suggestions,
+        $suggestions = array_filter(
+            $suggestions,
             fn (string $suggestion): bool => in_array(preg_match('/[^a-zA-Z]/', $suggestion), [0, false], true)
         );
 
@@ -101,14 +103,41 @@ final class Aspell implements Spellchecker
 
         $output = $process->getOutput();
 
-        return array_values(array_map(function (string $line): Misspelling {
-            [$wordMetadataAsString, $suggestionsAsString] = explode(':', trim($line));
+        return array_values(array_map(fn (string $line): Misspelling => $this->createMisspellingFromLine($line), $this->getLinesFromOutput($output)));
+    }
 
-            $word = explode(' ', $wordMetadataAsString)[1];
-            $suggestions = explode(', ', trim($suggestionsAsString));
+    /**
+     * Returns the lines from the output of the Aspell command.
+     * Lines with suggestions start with '&' and lines without suggestions start with '#'.
+     *
+     * @return array<int,string>
+     */
+    private function getLinesFromOutput(string $output): array
+    {
+        return array_filter(
+            explode(PHP_EOL, $output),
+            fn (string $line): bool => str_starts_with($line, '&') || str_starts_with($line, '#')
+        );
+    }
 
-            return new Misspelling($word, $this->takeSuggestions($suggestions));
-        }, array_filter(explode(PHP_EOL, $output), fn (string $line): bool => str_starts_with($line, '&'))));
+    /**
+     * Creates a new instance of Misspelling from the given line.
+     * The suggestions are empty if there are no suggestions.
+     */
+    private function createMisspellingFromLine(string $line): Misspelling
+    {
+        [$wordMetadataAsString, $suggestionsAsString] = explode(':', trim($line)) + [1 => null];
+
+        $word = explode(' ', (string) $wordMetadataAsString)[1];
+
+        // If there are no suggestions, return an empty array
+        if ($suggestionsAsString === null || ($suggestionsAsString === '' || $suggestionsAsString === '0')) {
+            return new Misspelling($word, []);
+        }
+
+        $suggestions = explode(', ', trim($suggestionsAsString));
+
+        return new Misspelling($word, $this->takeSuggestions($suggestions));
     }
 
     /**

--- a/tests/Console/OutputTest.php
+++ b/tests/Console/OutputTest.php
@@ -59,3 +59,13 @@ it('may pass with static text option', function (): void {
     expect($exitCode)->toBe(0)
         ->and($output)->toMatchSnapshot();
 });
+
+it('handles misspellings without suggestions', function (): void {
+    $process = Process::fromShellCommandline('./bin/peck --text="Xxxxxxxxxxxxxxxxxx"');
+
+    $exitCode = $process->run();
+    $output = $process->getOutput();
+
+    expect($exitCode)->toBe(1);
+    expect($output)->toContain('No suggestions available.');
+});

--- a/tests/Unit/Services/AspellTest.php
+++ b/tests/Unit/Services/AspellTest.php
@@ -115,3 +115,16 @@ it('ignores alpha-3 country codes', function (): void {
 
     expect($issues)->toBeEmpty();
 });
+
+it('detects misspellings without suggestions', function (): void {
+    $aspell = new Aspell(
+        Config::instance(),
+        Cache::default(),
+    );
+
+    $misspellings = $aspell->check('Xxxxxxxxxxxxxxxxxx');
+
+    expect($misspellings)->not->toBeEmpty()
+        ->and($misspellings[0]->word)->toBe('Xxxxxxxxxxxxxxxxxx')
+        ->and($misspellings[0]->suggestions)->toBeEmpty();
+});


### PR DESCRIPTION

### What:

- [X] Bug Fix
- [ ] New Feature

### Description:

This pull request handles the Aspell response so that misspellings without a suggestion are also marked as a misspelling.
I also adjusted the output accordingly and added testing.

### Related:

- #100 
