### PR TITLE
[Checker]: Check String Tokens in Code

### DIFF
--- a/peck.json
+++ b/peck.json
@@ -2,7 +2,9 @@
     "preset": "base",
     "ignore": {
         "words": [
-            "php"
+            "php",
+            "strtolower",
+            "fg"
         ],
         "paths": [
             "tests"

--- a/stubs/presets/base.stub
+++ b/stubs/presets/base.stub
@@ -119,6 +119,7 @@ sqs
 src
 ssl
 sso
+str
 stringable
 symfony
 throwable
@@ -139,6 +140,7 @@ unformatted
 unsuspend
 upsert
 uri
+utf
 uuid
 validator
 verifier


### PR DESCRIPTION
### What:

- [ ] Bug Fix
- [X] New Feature

### Description:

This is a draft pull request utilizing the tokenization attempt in order to check for strings in the current files!
Currently I still see a set of problems with this attempt:

1. This double-checks backend enum values
2. Somehow regex has to be detected in order to avoid marking regex as a typo.
3. array_map('some_php_function') will trigger a typo regarding the given php_function.

### Related:

- #136
