### PR TITLE
feat: ignore words per file

### DIFF
--- a/src/Checkers/FileSystemChecker.php
+++ b/src/Checkers/FileSystemChecker.php
@@ -53,7 +53,7 @@ final readonly class FileSystemChecker implements Checker
                     $misspelling,
                     $fileOrDirectory->getRealPath(),
                     0,
-                ), $this->spellchecker->check($name),
+                ), $this->spellchecker->check($name, $fileOrDirectory->getRealPath()),
             );
 
             $issues = [

--- a/src/Checkers/SourceCodeChecker.php
+++ b/src/Checkers/SourceCodeChecker.php
@@ -118,7 +118,7 @@ final readonly class SourceCodeChecker implements Checker
                         $misspelling,
                         $file->getRealPath(),
                         $this->getErrorLine($file, $name),
-                    ), $this->spellchecker->check(SpellcheckFormatter::format($name))),
+                    ), $this->spellchecker->check(SpellcheckFormatter::format($name), $file->getRealPath())),
             ];
         }
 

--- a/src/Contracts/Services/Spellchecker.php
+++ b/src/Contracts/Services/Spellchecker.php
@@ -16,5 +16,5 @@ interface Spellchecker
      *
      * @return array<int, Misspelling>
      */
-    public function check(string $text): array;
+    public function check(string $text, ?string $filePath = null): array;
 }

--- a/src/Services/Spellcheckers/Aspell.php
+++ b/src/Services/Spellcheckers/Aspell.php
@@ -43,7 +43,7 @@ final class Aspell implements Spellchecker
      *
      * @return array<int, Misspelling>
      */
-    public function check(string $text): array
+    public function check(string $text, ?string $filePath = null): array
     {
         /** @var array<int, Misspelling>|null $misspellings */
         $misspellings = $this->cache->has($text) ? $this->cache->get($text) : $this->getMisspellings($text);
@@ -53,7 +53,7 @@ final class Aspell implements Spellchecker
         }
 
         return array_filter($misspellings,
-            fn (Misspelling $misspelling): bool => ! $this->config->isWordIgnored($misspelling->word),
+            fn (Misspelling $misspelling): bool => ! $this->config->isWordIgnored($misspelling->word, $filePath),
         );
     }
 

--- a/tests/Unit/ConfigTest.php
+++ b/tests/Unit/ConfigTest.php
@@ -11,7 +11,7 @@ it('should have a default configuration', function (): void {
         'php',
     ])->and($config->whitelistedPaths)->toBe([
         'tests',
-    ]);
+    ])->and($config->fileSpecificIgnores)->toBe([]);
 });
 
 it('should to be a singleton', function (): void {
@@ -29,7 +29,8 @@ it('should behave correctly even if the peck.json file does not exist', function
     $config = Config::instance();
 
     expect($config->whitelistedWords)->toBe([])
-        ->and($config->whitelistedPaths)->toBe([]);
+        ->and($config->whitelistedPaths)->toBe([])
+        ->and($config->fileSpecificIgnores)->toBe([]);
 });
 
 it('should be able to create a peck.json config file', function (): void {
@@ -57,5 +58,5 @@ it('should not recreate a file that already exists', function (): void {
         ])
         ->and($config->whitelistedPaths)->toBe([
             'tests',
-        ]);
+        ])->and($config->fileSpecificIgnores)->toBe([]);
 });


### PR DESCRIPTION
### What:

- [ ] Bug Fix
- [x] New Feature

### Description:

There are a few cases where unfortunately we can't fix the typo that peck is finding and I don't want to explicitly ignore the word since it can then get added to new files being able to explicitly ignore a word per file will be handy since it lets us fix the errors we can and then ignore the ones we can't but still prevent it from happening again in new places.

example peck.json
```json
{
    "preset": "laravel",
    "ignore": {
        "words": [
            "php"
        ],
        "paths": [
        ],
        "files": {
            "app/somefile/typo.php": [
                "typo"
            ]
        }
    }
}
```

#### Note:
I've not updated the read me yet, if you're happy with these changes I can update the docs to include more information about this.