### PR TITLE
Symfony 8 support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,8 +10,13 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest]
         php: ['8.2', '8.3', '8.4']
-        symfony: ['^6.4', '^7.2']
+        symfony: ['^6.4', '^7.2', '^8.0']
         dependency-version: [prefer-lowest, prefer-stable]
+        exclude:
+          - php: '8.2'
+            symfony: '^8.0'
+          - php: '8.3'
+            symfony: '^8.0'
 
     name: Tests P${{ matrix.php }} - ${{ matrix.os }} - ${{ matrix.dependency-version }} (Symfony ${{ matrix.symfony }})
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+- Added support for Symfony 8
+
 ## [v0.2.0] - 2025-06-10
 - Included symfony/process as dependency (resolves issues for some installations)
 - Added `language` option to configuration file (defaults to `en_US`)

--- a/bin/peck
+++ b/bin/peck
@@ -5,6 +5,7 @@ declare(strict_types=1);
 
 use Peck\Console\Commands\CheckCommand;
 use Symfony\Component\Console\Application;
+use Symfony\Component\Console\CommandLoader\FactoryCommandLoader;
 
 foreach ([
     dirname(__DIR__, 4).'/vendor/autoload.php',
@@ -22,9 +23,9 @@ $application = new Application(
     '0.2.0',
 );
 
-$application->add(
-    new CheckCommand,
-);
+$application->setCommandLoader(new FactoryCommandLoader([
+    'check' => static fn (): CheckCommand => new CheckCommand,
+]));
 
 $application->setDefaultCommand('check');
 

--- a/composer.json
+++ b/composer.json
@@ -17,9 +17,9 @@
     "require": {
         "php": "^8.2",
         "nunomaduro/termwind": "^1.17.0|^2.3.0",
-        "symfony/console": "^6.4.17|^7.2.1",
-        "symfony/finder": "^6.4.17|^7.2.2",
-        "symfony/process": "^6.4.17|^7.2.2"
+        "symfony/console": "^6.4.17|^7.2.1|^8.0",
+        "symfony/finder": "^6.4.17|^7.2.2|^8.0",
+        "symfony/process": "^6.4.17|^7.2.2|^8.0"
     },
     "require-dev": {
         "laravel/pint": "^1.20.0",
@@ -27,7 +27,7 @@
         "pestphp/pest-plugin-type-coverage": "^2.8.7|^3.2.3",
         "phpstan/phpstan": "^1.12.16",
         "rector/rector": "^1.2.10",
-        "symfony/var-dumper": "^7.2.0"
+        "symfony/var-dumper": "^7.2.0|^8.0"
     },
     "autoload": {
         "psr-4": {

--- a/tests/Integration/CheckCommandTest.php
+++ b/tests/Integration/CheckCommandTest.php
@@ -3,17 +3,10 @@
 declare(strict_types=1);
 
 use Peck\Console\Commands\CheckCommand;
-use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Tester\CommandTester;
 
 it('may fail', function (): void {
-    $application = new Application;
-
-    $application->add(new CheckCommand);
-
-    $command = $application->find('check');
-
-    $commandTester = new CommandTester($command);
+    $commandTester = new CommandTester(new CheckCommand);
 
     $commandTester->execute([
         '--path' => 'tests/Fixtures/ClassesToTest/FolderThatShouldBeIgnored',
@@ -26,13 +19,7 @@ it('may fail', function (): void {
 });
 
 it('may pass', function (): void {
-    $application = new Application;
-
-    $application->add(new CheckCommand);
-
-    $command = $application->find('check');
-
-    $commandTester = new CommandTester($command);
+    $commandTester = new CommandTester(new CheckCommand);
 
     $commandTester->execute([]);
 
@@ -43,13 +30,7 @@ it('may pass', function (): void {
 });
 
 it('may pass with lineless issues', function (): void {
-    $application = new Application;
-
-    $application->add(new CheckCommand);
-
-    $command = $application->find('check');
-
-    $commandTester = new CommandTester($command);
+    $commandTester = new CommandTester(new CheckCommand);
 
     $commandTester->execute([
         '--path' => 'tests/Fixtures/FolderWithTypoos',
@@ -62,13 +43,7 @@ it('may pass with lineless issues', function (): void {
 });
 
 it('may pass with init option', function (): void {
-    $application = new Application;
-
-    $application->add(new CheckCommand);
-
-    $command = $application->find('check');
-
-    $commandTester = new CommandTester($command);
+    $commandTester = new CommandTester(new CheckCommand);
 
     $commandTester->execute([
         '--init' => true,
@@ -81,13 +56,7 @@ it('may pass with init option', function (): void {
 });
 
 it('may pass with ignore-all option', function (): void {
-    $application = new Application;
-
-    $application->add(new CheckCommand);
-
-    $command = $application->find('check');
-
-    $commandTester = new CommandTester($command);
+    $commandTester = new CommandTester(new CheckCommand);
 
     $commandTester->execute([
         '--ignore-all' => true,
@@ -101,13 +70,7 @@ it('may pass with ignore-all option', function (): void {
 });
 
 it('may fail with text option', function (): void {
-    $application = new Application;
-
-    $application->add(new CheckCommand);
-
-    $command = $application->find('check');
-
-    $commandTester = new CommandTester($command);
+    $commandTester = new CommandTester(new CheckCommand);
 
     $commandTester->execute([
         '--text' => 'This is a test with a typoo.',
@@ -120,13 +83,7 @@ it('may fail with text option', function (): void {
 });
 
 it('may pass with text option', function (): void {
-    $application = new Application;
-
-    $application->add(new CheckCommand);
-
-    $command = $application->find('check');
-
-    $commandTester = new CommandTester($command);
+    $commandTester = new CommandTester(new CheckCommand);
 
     $commandTester->execute([
         '--text' => 'This is a test without any typos.',


### PR DESCRIPTION
### What:

- [ ] Bug Fix
- [x] New Feature

### Description:

Symfony Console deprecated Application::add() in Symfony 7 and removed it in Symfony 8. This package still supports Symfony 6, so instead of adding version-specific conditionals we moved to the command-loader API, which is supported across Symfony 6/7/8.

Tests were executed on my own fork and the complete test matrix seems to be successful.

### Related:

(https://github.com/peckphp/peck/issues/169)
