### PR TITLE
Add nightwatch to Laravel stub presets

### DIFF
--- a/stubs/presets/laravel.stub
+++ b/stubs/presets/laravel.stub
@@ -9,5 +9,6 @@ inertia
 inertiajs
 jetstream
 laratrust
+nightwatch
 typesense
 ulid


### PR DESCRIPTION
### Description:

This PR introduces a new word: **Nightwatch**, from Laravel Nightwatch (`nightwatch.laravel.com`).